### PR TITLE
fix: use ${HOME} instead of ~ for default remote directory

### DIFF
--- a/docs/dx-issues.md
+++ b/docs/dx-issues.md
@@ -124,15 +124,16 @@ export PATH="/opt/homebrew/bin:$PATH"
 
 **Root Cause:** `~` is not expanded when used in `dir` or `remote_dir` config values.
 
-**Workaround:** Use absolute paths:
+**Workaround:** Use `${HOME}` instead of `~`, or use absolute paths:
 ```yaml
 hosts:
   myhost:
-    dir: /Users/username/rr-sync/project  # Works
+    dir: ${HOME}/rr/project               # Works (default since v0.4)
+    dir: /Users/username/rr-sync/project  # Also works
     # dir: ~/rr-sync/project              # Doesn't work
 ```
 
-**Recommended Fix:** Expand `~` to `$HOME` when parsing config.
+**Status:** `rr init` now defaults to `${HOME}/rr/${PROJECT}` which works correctly.
 
 ### 8. Missing Dependency Handling
 

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -66,7 +66,7 @@ func hostAdd(opts HostAddOptions) error {
 			}
 		}
 		if remoteDir == "" {
-			remoteDir = "~/rr/${PROJECT}"
+			remoteDir = "${HOME}/rr/${PROJECT}"
 		}
 
 		// Prompt to confirm or change

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -140,7 +140,7 @@ func collectNonInteractiveValues(opts InitOptions) (*initConfigValues, error) {
 	}
 	vals.remoteDir = opts.Dir
 	if vals.remoteDir == "" {
-		vals.remoteDir = "~/rr/${PROJECT}"
+		vals.remoteDir = "${HOME}/rr/${PROJECT}"
 	}
 	return vals, nil
 }
@@ -216,7 +216,7 @@ func getAllSelectedSSHHosts(machines []machineConfig) []string {
 // collectInteractiveValues collects config values interactively.
 func collectInteractiveValues() (*initConfigValues, error) {
 	vals := &initConfigValues{
-		remoteDir: "~/rr/${PROJECT}", // Default, will prompt at end
+		remoteDir: "${HOME}/rr/${PROJECT}", // Default, will prompt at end
 	}
 
 	// Machine loop - collect one or more machines
@@ -397,7 +397,7 @@ func promptRemoteDir(remoteDir *string) error {
 			huh.NewInput().
 				Title("Remote directory").
 				Description("Where files sync to on all machines (supports ${PROJECT}, ${USER}, ${HOME})").
-				Placeholder("~/rr/${PROJECT}").
+				Placeholder("${HOME}/rr/${PROJECT}").
 				Value(remoteDir).
 				Validate(func(s string) error {
 					if strings.TrimSpace(s) == "" {

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -321,5 +321,5 @@ func TestInit_NonInteractive_DefaultRemoteDir(t *testing.T) {
 	content, err := os.ReadFile(filepath.Join(tmpDir, ".rr.yaml"))
 	require.NoError(t, err)
 	// Default remote dir should be used
-	assert.Contains(t, string(content), "~/rr/${PROJECT}")
+	assert.Contains(t, string(content), "${HOME}/rr/${PROJECT}")
 }


### PR DESCRIPTION
## Summary
- Changed `rr init` default remote dir from `~/rr/${PROJECT}` to `${HOME}/rr/${PROJECT}`
- The tilde `~` doesn't expand properly in all shell contexts, causing "no such file or directory" errors
- `${HOME}` expands correctly when the remote shell executes the cd command

## Test plan
- [x] Unit tests updated and passing
- [x] `make verify` passes (lint + tests)
- [ ] Manual test: `rr init` in a new project shows `${HOME}/rr/${PROJECT}` as the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)