### PR TITLE
fix(ci): improve SSH server startup reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,26 +127,53 @@ jobs:
             -e PUBLIC_KEY="$(cat /tmp/rr-ci-ssh-keys/id_ed25519.pub)" \
             linuxserver/openssh-server
 
-          # Wait for SSH to be ready
-          echo "Waiting for SSH server..."
-          for i in {1..30}; do
-            if nc -z localhost 2222 2>/dev/null; then
-              echo "SSH server is ready"
-              break
+          # Wait for SSH daemon to be fully ready (not just port open)
+          echo "Waiting for SSH server to initialize..."
+          for i in {1..60}; do
+            # Check if sshd process is running inside container
+            if docker exec rr-ci-ssh pgrep -x sshd >/dev/null 2>&1; then
+              # Also verify TCP port is accepting connections
+              if nc -z localhost 2222 2>/dev/null; then
+                echo "SSH server is ready (attempt $i)"
+                break
+              fi
             fi
-            sleep 1
+            echo "Waiting... (attempt $i)"
+            sleep 2
           done
+
+          # Additional settle time for key configuration
+          sleep 3
 
           # Add to known_hosts
           mkdir -p ~/.ssh
-          ssh-keyscan -p 2222 localhost >> ~/.ssh/known_hosts 2>/dev/null || true
+          for i in {1..5}; do
+            if ssh-keyscan -p 2222 localhost >> ~/.ssh/known_hosts 2>/dev/null; then
+              echo "Added host key to known_hosts"
+              break
+            fi
+            sleep 2
+          done
 
-          # Verify connection
-          ssh -i /tmp/rr-ci-ssh-keys/id_ed25519 \
-              -p 2222 \
-              -o StrictHostKeyChecking=no \
-              -o ConnectTimeout=10 \
-              testuser@localhost "echo 'SSH connection successful'"
+          # Verify connection with retries
+          echo "Verifying SSH connection..."
+          for i in {1..5}; do
+            if ssh -i /tmp/rr-ci-ssh-keys/id_ed25519 \
+                -p 2222 \
+                -o StrictHostKeyChecking=no \
+                -o ConnectTimeout=10 \
+                testuser@localhost "echo 'SSH connection successful'"; then
+              echo "Connection verified!"
+              exit 0
+            fi
+            echo "Connection attempt $i failed, retrying..."
+            sleep 3
+          done
+
+          # If we get here, show logs for debugging
+          echo "SSH connection failed after retries. Container logs:"
+          docker logs rr-ci-ssh
+          exit 1
 
       - name: Run integration tests
         env:


### PR DESCRIPTION
## Summary
- Fixed flaky integration tests that failed with "Connection reset by peer"
- The SSH container was being probed before sshd was fully initialized
- Now checks for sshd process inside container, not just open port
- Added settle time and retries for more reliable startup
- Container logs are printed on failure for easier debugging

## Test plan
- [x] YAML validation passes
- [ ] CI integration tests should pass consistently now

🤖 Generated with [Claude Code](https://claude.com/claude-code)