### PR TITLE
fix(ci): use go.mod for Go version instead of hardcoded matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,14 @@ concurrency:
 
 jobs:
   test:
-    name: Test (Go ${{ matrix.go-version }})
+    name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.22', '1.23', '1.24']
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version-file: go.mod
           cache: true
 
       - name: Check formatting
@@ -44,7 +41,7 @@ jobs:
       - name: Generate test summary
         if: always()
         run: |
-          echo "## Test Results (Go ${{ matrix.go-version }})" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
           # Count results from JSON output
@@ -78,7 +75,7 @@ jobs:
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v6
         with:
-          name: coverage-go${{ matrix.go-version }}
+          name: coverage
           path: coverage.out
           retention-days: 30
 
@@ -90,7 +87,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Run govulncheck
@@ -106,7 +103,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Start SSH test server
@@ -198,7 +195,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
           cache: true
 
       - name: Build


### PR DESCRIPTION
## Summary
- Removed Go version matrix (was testing 1.22, 1.23, 1.24)
- Now uses `go-version-file: go.mod` to automatically pick up Go 1.24.2
- The go.mod requires Go 1.24.2, so testing older versions was always going to fail

## Test plan
- [x] YAML validation passes
- [ ] CI should now pass without Go version mismatches

🤖 Generated with [Claude Code](https://claude.com/claude-code)