### PR TITLE
chore: bump Go version to 1.24.4 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.24.2
+go 1.24.4
 
 require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7


### PR DESCRIPTION
## Summary
- Bumps Go from 1.24.2 to 1.24.4
- Fixes GO-2025-3749 and other stdlib vulnerabilities detected by govulncheck
- Security scan should pass now

## Test plan
- [x] `govulncheck ./...` passes locally
- [ ] CI security scan should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)