### PR TITLE
chore: bump Go to 1.24.9 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.24.4
+go 1.24.9
 
 require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7


### PR DESCRIPTION
## Summary
- Bumps Go from 1.24.4 to 1.24.9
- Fixes all current stdlib vulnerabilities detected by govulncheck:
  - GO-2025-4008 (crypto/tls, fixed in 1.24.8)
  - GO-2025-4007 (crypto/x509, fixed in 1.24.9)  
  - GO-2025-3956 (os/exec, fixed in 1.24.6)

## Test plan
- [x] `govulncheck ./...` passes locally
- [ ] CI security scan should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)