### PR TITLE
chore: bump Go to 1.24.11 for security fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.24.9
+go 1.24.11
 
 require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7


### PR DESCRIPTION
## Summary
- Bumps Go from 1.24.9 to 1.24.11
- Fixes remaining stdlib vulnerabilities:
  - GO-2025-4175 (crypto/x509 wildcard name constraints)
  - GO-2025-4155 (crypto/x509 error string resource consumption)

## Test plan
- [x] `govulncheck ./...` passes locally
- [ ] CI security scan should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)