### PR TITLE
fix(ci): use go.mod for Go version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser


### PR DESCRIPTION
## Summary
- Release workflow was using Go 1.22 but go.mod requires 1.24.11
- This caused v0.3.3 release to fail
- Now uses go-version-file: go.mod like the CI workflow

## Test plan
- [ ] New tag should trigger a successful release

🤖 Generated with [Claude Code](https://claude.com/claude-code)