### PR TITLE
feat(cli): add interactive tool provisioning when commands fail

### DIFF
--- a/internal/cli/fix.go
+++ b/internal/cli/fix.go
@@ -1,0 +1,218 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/charmbracelet/huh"
+	"github.com/rileyhilliard/rr/internal/config"
+	"github.com/rileyhilliard/rr/internal/exec"
+	"github.com/rileyhilliard/rr/internal/ui"
+	"golang.org/x/term"
+)
+
+// FixOption represents a choice in the fix menu.
+type FixOption string
+
+const (
+	FixOptionInstall FixOption = "install"
+	FixOptionPATH    FixOption = "path"
+	FixOptionSkip    FixOption = "skip"
+)
+
+// FixResult contains the result of attempting to fix a missing tool error.
+type FixResult struct {
+	Fixed       bool   // Whether the fix was applied
+	ShouldRetry bool   // Whether the user wants to retry the command
+	Message     string // Human-readable message about what happened
+}
+
+// HandleMissingTool presents the user with options to fix a missing tool error.
+// It returns a FixResult indicating what action was taken.
+func HandleMissingTool(
+	missingTool *exec.MissingToolError,
+	sshClient exec.SSHStreamer,
+	configPath string,
+) (*FixResult, error) {
+	// Can't show interactive prompts without a terminal
+	if !term.IsTerminal(int(os.Stdin.Fd())) {
+		return &FixResult{Fixed: false, ShouldRetry: false}, nil
+	}
+
+	// Build fix options based on what's available
+	options := buildFixOptions(missingTool)
+	if len(options) == 0 {
+		return &FixResult{Fixed: false, ShouldRetry: false}, nil
+	}
+
+	// Show fix menu
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Would you like rr to fix this?").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		// User cancelled
+		return &FixResult{Fixed: false, ShouldRetry: false}, nil
+	}
+
+	// Execute the selected fix
+	switch FixOption(selected) {
+	case FixOptionInstall:
+		return executeInstallFix(missingTool, sshClient, configPath)
+	case FixOptionPATH:
+		return executePATHFix(missingTool, configPath)
+	case FixOptionSkip:
+		return &FixResult{Fixed: false, ShouldRetry: false}, nil
+	}
+
+	return &FixResult{Fixed: false, ShouldRetry: false}, nil
+}
+
+// buildFixOptions creates the menu options based on the missing tool error.
+func buildFixOptions(missingTool *exec.MissingToolError) []huh.Option[string] {
+	var options []huh.Option[string]
+
+	// Option 1: Install (if we have an installer)
+	if missingTool.CanInstall {
+		options = append(options, huh.NewOption(
+			fmt.Sprintf("Install '%s' on the remote machine", missingTool.ToolName),
+			string(FixOptionInstall),
+		))
+	}
+
+	// Option 2: Add PATH export (if tool was found but not in PATH)
+	if missingTool.FoundButNotInPATH() {
+		pathDir := missingTool.GetPATHToAdd()
+		if pathDir != "" {
+			options = append(options, huh.NewOption(
+				fmt.Sprintf("Add PATH export to .rr.yaml (found in %s)", pathDir),
+				string(FixOptionPATH),
+			))
+		}
+	}
+
+	// Option 3: Skip
+	options = append(options, huh.NewOption("Skip", string(FixOptionSkip)))
+
+	return options
+}
+
+// executeInstallFix attempts to install the tool on the remote machine.
+func executeInstallFix(
+	missingTool *exec.MissingToolError,
+	sshClient exec.SSHStreamer,
+	configPath string,
+) (*FixResult, error) {
+	if sshClient == nil {
+		return &FixResult{
+			Fixed:   false,
+			Message: "No SSH connection available for installation",
+		}, nil
+	}
+
+	// Detect remote OS for display
+	osName, err := exec.DetectRemoteOS(sshClient)
+	if err != nil {
+		osName = "unknown"
+	}
+
+	// Show what we're about to do
+	installDesc := exec.GetInstallCommandDescription(missingTool.ToolName, osName)
+	fmt.Printf("\nInstalling '%s' on %s...\n", missingTool.ToolName, missingTool.HostName)
+	if installDesc != "" {
+		fmt.Printf("  Running: %s\n\n", installDesc)
+	}
+
+	// Run the installation with streaming output
+	result, err := exec.InstallTool(sshClient, missingTool.ToolName, os.Stdout, os.Stderr)
+	if err != nil {
+		fmt.Printf("\n%s Installation failed: %v\n", ui.SymbolFail, err)
+		return &FixResult{Fixed: false, Message: err.Error()}, nil
+	}
+
+	if !result.Success {
+		fmt.Printf("\n%s Installation failed: %s\n", ui.SymbolFail, result.Output)
+		return &FixResult{Fixed: false, Message: result.Output}, nil
+	}
+
+	fmt.Printf("\n%s Installed '%s' successfully\n", ui.SymbolSuccess, missingTool.ToolName)
+
+	// If there are PATH additions needed, offer to add them to config
+	if len(result.PathAdditions) > 0 {
+		exportCmd := config.GeneratePATHExportCommand(result.PathAdditions)
+		if exportCmd != "" {
+			var addToConfig bool
+			pathForm := huh.NewForm(
+				huh.NewGroup(
+					huh.NewConfirm().
+						Title(fmt.Sprintf("Add PATH export to .rr.yaml?\n  %s", exportCmd)).
+						Value(&addToConfig),
+				),
+			)
+			if pathForm.Run() == nil && addToConfig {
+				if err := config.AddSetupCommand(configPath, missingTool.HostName, exportCmd); err != nil {
+					fmt.Printf("%s Failed to update config: %v\n", ui.SymbolFail, err)
+				} else {
+					fmt.Printf("%s Added setup_command to .rr.yaml\n", ui.SymbolSuccess)
+				}
+			}
+		}
+	}
+
+	// Ask if user wants to retry
+	shouldRetry := promptRetry()
+
+	return &FixResult{
+		Fixed:       true,
+		ShouldRetry: shouldRetry,
+		Message:     fmt.Sprintf("Installed '%s'", missingTool.ToolName),
+	}, nil
+}
+
+// executePATHFix adds a PATH export to the config file.
+func executePATHFix(missingTool *exec.MissingToolError, configPath string) (*FixResult, error) {
+	pathDir := missingTool.GetPATHToAdd()
+	if pathDir == "" {
+		return &FixResult{Fixed: false, Message: "Could not determine PATH to add"}, nil
+	}
+
+	exportCmd := config.GeneratePATHExportCommand([]string{pathDir})
+
+	if err := config.AddSetupCommand(configPath, missingTool.HostName, exportCmd); err != nil {
+		fmt.Printf("%s Failed to update config: %v\n", ui.SymbolFail, err)
+		return &FixResult{Fixed: false, Message: err.Error()}, nil
+	}
+
+	fmt.Printf("\n%s Added setup_command to .rr.yaml:\n    %s\n", ui.SymbolSuccess, exportCmd)
+
+	// Ask if user wants to retry
+	shouldRetry := promptRetry()
+
+	return &FixResult{
+		Fixed:       true,
+		ShouldRetry: shouldRetry,
+		Message:     fmt.Sprintf("Added PATH export: %s", exportCmd),
+	}, nil
+}
+
+// promptRetry asks the user if they want to retry the command.
+func promptRetry() bool {
+	var retry bool
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewConfirm().
+				Title("Retry the command?").
+				Value(&retry),
+		),
+	)
+	if form.Run() != nil {
+		return false
+	}
+	return retry
+}

--- a/internal/config/update.go
+++ b/internal/config/update.go
@@ -1,0 +1,164 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// AddSetupCommand adds a setup command to a specific host in the config file.
+// It preserves the existing YAML structure and comments.
+// If the setup command already exists, it does nothing.
+func AddSetupCommand(configPath, hostName, setupCommand string) error {
+	// Read the existing file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Parse as yaml.Node to preserve structure
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	// Navigate to hosts.<hostName>.setup_commands
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return fmt.Errorf("invalid YAML document structure")
+	}
+
+	docNode := root.Content[0]
+	if docNode.Kind != yaml.MappingNode {
+		return fmt.Errorf("expected mapping at document root")
+	}
+
+	// Find hosts key
+	hostsNode := findMapValue(docNode, "hosts")
+	if hostsNode == nil {
+		return fmt.Errorf("'hosts' key not found in config")
+	}
+
+	// Find the specific host
+	hostNode := findMapValue(hostsNode, hostName)
+	if hostNode == nil {
+		return fmt.Errorf("host '%s' not found in config", hostName)
+	}
+
+	// Find or create setup_commands
+	setupCommandsNode := findMapValue(hostNode, "setup_commands")
+	if setupCommandsNode == nil {
+		// Need to add setup_commands to this host
+		setupCommandsNode = &yaml.Node{
+			Kind:    yaml.SequenceNode,
+			Tag:     "!!seq",
+			Content: []*yaml.Node{},
+		}
+
+		// Add the key-value pair to the host mapping
+		keyNode := &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: "setup_commands",
+		}
+
+		hostNode.Content = append(hostNode.Content, keyNode, setupCommandsNode)
+	}
+
+	// Check if command already exists
+	for _, item := range setupCommandsNode.Content {
+		if item.Kind == yaml.ScalarNode && item.Value == setupCommand {
+			// Already exists, nothing to do
+			return nil
+		}
+	}
+
+	// Add the new command
+	newCmd := &yaml.Node{
+		Kind:  yaml.ScalarNode,
+		Tag:   "!!str",
+		Value: setupCommand,
+	}
+	setupCommandsNode.Content = append(setupCommandsNode.Content, newCmd)
+
+	// Write back to file
+	var buf strings.Builder
+	encoder := yaml.NewEncoder(&buf)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&root); err != nil {
+		return fmt.Errorf("failed to encode config: %w", err)
+	}
+	encoder.Close()
+
+	if err := os.WriteFile(configPath, []byte(buf.String()), 0644); err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	return nil
+}
+
+// findMapValue finds a value in a mapping node by key name.
+func findMapValue(node *yaml.Node, key string) *yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(node.Content)-1; i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+
+		if keyNode.Kind == yaml.ScalarNode && keyNode.Value == key {
+			return valueNode
+		}
+	}
+
+	return nil
+}
+
+// GeneratePATHExportCommand creates an export command for adding directories to PATH.
+func GeneratePATHExportCommand(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+
+	// Convert absolute paths to $HOME-relative
+	relativePaths := make([]string, len(paths))
+	for i, p := range paths {
+		relativePaths[i] = toHomeRelativePath(p)
+	}
+
+	return fmt.Sprintf("export PATH=%s:$PATH", strings.Join(relativePaths, ":"))
+}
+
+// toHomeRelativePath converts absolute paths starting with common home patterns
+// to $HOME-relative paths for portability across users.
+func toHomeRelativePath(path string) string {
+	// If already using $HOME, return as-is
+	if strings.HasPrefix(path, "$HOME") {
+		return path
+	}
+
+	// Common home directory patterns
+	prefixes := []string{
+		"/Users/", // macOS
+		"/home/",  // Linux
+		"/root",   // root user
+	}
+
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(path, prefix) {
+			rest := path[len(prefix):]
+			if prefix == "/root" {
+				return "$HOME" + rest
+			}
+			// Skip past username to get the rest of the path
+			if idx := strings.Index(rest, "/"); idx != -1 {
+				return "$HOME" + rest[idx:]
+			}
+			return "$HOME"
+		}
+	}
+
+	return path
+}

--- a/internal/config/update_test.go
+++ b/internal/config/update_test.go
@@ -1,0 +1,220 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAddSetupCommand(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialYAML  string
+		hostName     string
+		setupCommand string
+		wantContains []string
+		wantErr      bool
+	}{
+		{
+			name: "add to host without setup_commands",
+			initialYAML: `version: 1
+hosts:
+  myhost:
+    ssh:
+      - myhost.local
+    dir: /home/user/project
+`,
+			hostName:     "myhost",
+			setupCommand: "export PATH=$HOME/go/bin:$PATH",
+			wantContains: []string{
+				"setup_commands:",
+				"export PATH=$HOME/go/bin:$PATH",
+			},
+		},
+		{
+			name: "add to host with existing setup_commands",
+			initialYAML: `version: 1
+hosts:
+  myhost:
+    ssh:
+      - myhost.local
+    dir: /home/user/project
+    setup_commands:
+      - export EXISTING=1
+`,
+			hostName:     "myhost",
+			setupCommand: "export PATH=$HOME/go/bin:$PATH",
+			wantContains: []string{
+				"export EXISTING=1",
+				"export PATH=$HOME/go/bin:$PATH",
+			},
+		},
+		{
+			name: "skip if command already exists",
+			initialYAML: `version: 1
+hosts:
+  myhost:
+    ssh:
+      - myhost.local
+    setup_commands:
+      - export PATH=$HOME/go/bin:$PATH
+`,
+			hostName:     "myhost",
+			setupCommand: "export PATH=$HOME/go/bin:$PATH",
+			wantContains: []string{
+				"export PATH=$HOME/go/bin:$PATH",
+			},
+		},
+		{
+			name: "error if host not found",
+			initialYAML: `version: 1
+hosts:
+  otherhost:
+    ssh:
+      - other.local
+`,
+			hostName:     "myhost",
+			setupCommand: "export PATH=$HOME/go/bin:$PATH",
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create temp file
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, ".rr.yaml")
+			err := os.WriteFile(configPath, []byte(tt.initialYAML), 0644)
+			require.NoError(t, err)
+
+			// Run the function
+			err = AddSetupCommand(configPath, tt.hostName, tt.setupCommand)
+
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+
+			// Read back the file
+			content, err := os.ReadFile(configPath)
+			require.NoError(t, err)
+
+			// Check expected content
+			for _, want := range tt.wantContains {
+				assert.Contains(t, string(content), want)
+			}
+		})
+	}
+}
+
+func TestAddSetupCommand_DoesNotDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, ".rr.yaml")
+
+	initialYAML := `version: 1
+hosts:
+  myhost:
+    ssh:
+      - myhost.local
+    dir: /home/user/project
+`
+	err := os.WriteFile(configPath, []byte(initialYAML), 0644)
+	require.NoError(t, err)
+
+	// Add command twice
+	err = AddSetupCommand(configPath, "myhost", "export PATH=$HOME/go/bin:$PATH")
+	require.NoError(t, err)
+
+	err = AddSetupCommand(configPath, "myhost", "export PATH=$HOME/go/bin:$PATH")
+	require.NoError(t, err)
+
+	// Read back and verify only one instance
+	content, err := os.ReadFile(configPath)
+	require.NoError(t, err)
+
+	count := strings.Count(string(content), "export PATH=$HOME/go/bin:$PATH")
+	assert.Equal(t, 1, count, "command should appear exactly once")
+}
+
+func TestGeneratePATHExportCommand(t *testing.T) {
+	tests := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{
+			name:  "single path",
+			paths: []string{"$HOME/go/bin"},
+			want:  "export PATH=$HOME/go/bin:$PATH",
+		},
+		{
+			name:  "multiple paths",
+			paths: []string{"$HOME/go/bin", "$HOME/.cargo/bin"},
+			want:  "export PATH=$HOME/go/bin:$HOME/.cargo/bin:$PATH",
+		},
+		{
+			name:  "empty paths",
+			paths: []string{},
+			want:  "",
+		},
+		{
+			name:  "absolute path converted to home relative",
+			paths: []string{"/home/user/go/bin"},
+			want:  "export PATH=$HOME/go/bin:$PATH",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GeneratePATHExportCommand(tt.paths)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestToHomeRelativePath(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "macOS home path",
+			input: "/Users/john/.local/bin",
+			want:  "$HOME/.local/bin",
+		},
+		{
+			name:  "Linux home path",
+			input: "/home/john/.cargo/bin",
+			want:  "$HOME/.cargo/bin",
+		},
+		{
+			name:  "root home path",
+			input: "/root/.local/bin",
+			want:  "$HOME/.local/bin",
+		},
+		{
+			name:  "already has $HOME",
+			input: "$HOME/go/bin",
+			want:  "$HOME/go/bin",
+		},
+		{
+			name:  "non-home path unchanged",
+			input: "/usr/local/bin",
+			want:  "/usr/local/bin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := toHomeRelativePath(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/internal/exec/provision.go
+++ b/internal/exec/provision.go
@@ -1,0 +1,236 @@
+package exec
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+// ToolInstaller defines how to install a specific tool on different platforms.
+type ToolInstaller struct {
+	Name string
+	// Installers maps OS name (darwin, linux) to install command.
+	// Commands should be idempotent or handle already-installed case.
+	Installers map[string]string
+	// PathAdditions are directories to add to PATH after installation.
+	// These use $HOME for portability.
+	PathAdditions []string
+}
+
+// SSHStreamer is an interface for executing SSH commands with streaming output.
+type SSHStreamer interface {
+	Exec(cmd string) (stdout, stderr []byte, exitCode int, err error)
+	ExecStream(cmd string, stdout, stderr io.Writer) (exitCode int, err error)
+}
+
+// toolInstallers contains installation instructions for common dev tools.
+var toolInstallers = map[string]ToolInstaller{
+	"go": {
+		Name: "go",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install go; else echo "Homebrew not found. Install from https://go.dev/dl/" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y golang-go; elif command -v yum &>/dev/null; then sudo yum install -y golang; elif command -v dnf &>/dev/null; then sudo dnf install -y golang; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{"$HOME/go/bin", "/usr/local/go/bin"},
+	},
+	"node": {
+		Name: "node",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install node; else echo "Homebrew not found" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs; elif command -v yum &>/dev/null; then curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo yum install -y nodejs; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"npm": {
+		Name: "npm",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install node; else echo "Homebrew not found" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo -E bash - && sudo apt-get install -y nodejs; elif command -v yum &>/dev/null; then curl -fsSL https://rpm.nodesource.com/setup_lts.x | sudo bash - && sudo yum install -y nodejs; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"python": {
+		Name: "python",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install python; else echo "Homebrew not found" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y python3 python3-pip; elif command -v yum &>/dev/null; then sudo yum install -y python3 python3-pip; elif command -v dnf &>/dev/null; then sudo dnf install -y python3 python3-pip; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"python3": {
+		Name: "python3",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install python; else echo "Homebrew not found" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y python3 python3-pip; elif command -v yum &>/dev/null; then sudo yum install -y python3 python3-pip; elif command -v dnf &>/dev/null; then sudo dnf install -y python3 python3-pip; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"pip": {
+		Name: "pip",
+		Installers: map[string]string{
+			"darwin": `if command -v brew &>/dev/null; then brew install python; else echo "Homebrew not found" && exit 1; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y python3-pip; elif command -v yum &>/dev/null; then sudo yum install -y python3-pip; elif command -v dnf &>/dev/null; then sudo dnf install -y python3-pip; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"cargo": {
+		Name: "cargo",
+		Installers: map[string]string{
+			"darwin": `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+			"linux":  `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+		},
+		PathAdditions: []string{"$HOME/.cargo/bin"},
+	},
+	"rust": {
+		Name: "rust",
+		Installers: map[string]string{
+			"darwin": `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+			"linux":  `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+		},
+		PathAdditions: []string{"$HOME/.cargo/bin"},
+	},
+	"rustc": {
+		Name: "rustc",
+		Installers: map[string]string{
+			"darwin": `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+			"linux":  `curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y`,
+		},
+		PathAdditions: []string{"$HOME/.cargo/bin"},
+	},
+	"make": {
+		Name: "make",
+		Installers: map[string]string{
+			"darwin": `xcode-select --install 2>/dev/null || true; if ! command -v make &>/dev/null && command -v brew &>/dev/null; then brew install make; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y build-essential; elif command -v yum &>/dev/null; then sudo yum groupinstall -y "Development Tools"; elif command -v dnf &>/dev/null; then sudo dnf groupinstall -y "Development Tools"; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+	"git": {
+		Name: "git",
+		Installers: map[string]string{
+			"darwin": `xcode-select --install 2>/dev/null || true; if ! command -v git &>/dev/null && command -v brew &>/dev/null; then brew install git; fi`,
+			"linux":  `if command -v apt-get &>/dev/null; then sudo apt-get update && sudo apt-get install -y git; elif command -v yum &>/dev/null; then sudo yum install -y git; elif command -v dnf &>/dev/null; then sudo dnf install -y git; else echo "No supported package manager found" && exit 1; fi`,
+		},
+		PathAdditions: []string{},
+	},
+}
+
+// GetToolInstaller returns the installer for a tool, if one exists.
+func GetToolInstaller(toolName string) (ToolInstaller, bool) {
+	installer, ok := toolInstallers[toolName]
+	return installer, ok
+}
+
+// CanInstallTool returns true if we have an installer for the given tool.
+func CanInstallTool(toolName string) bool {
+	_, ok := toolInstallers[toolName]
+	return ok
+}
+
+// DetectRemoteOS determines the OS of the remote machine via SSH.
+// Returns "darwin", "linux", or "unknown".
+func DetectRemoteOS(client SSHExecer) (string, error) {
+	stdout, _, exitCode, err := client.Exec("uname -s")
+	if err != nil {
+		return "unknown", fmt.Errorf("failed to detect OS: %w", err)
+	}
+	if exitCode != 0 {
+		return "unknown", fmt.Errorf("uname command failed with exit code %d", exitCode)
+	}
+
+	osName := strings.TrimSpace(strings.ToLower(string(stdout)))
+	switch osName {
+	case "darwin":
+		return "darwin", nil
+	case "linux":
+		return "linux", nil
+	default:
+		return "unknown", nil
+	}
+}
+
+// InstallToolResult contains the result of a tool installation attempt.
+type InstallToolResult struct {
+	Success       bool
+	Output        string
+	PathAdditions []string
+}
+
+// InstallTool attempts to install a tool on the remote machine.
+// Returns the result including any PATH additions needed.
+func InstallTool(client SSHStreamer, toolName string, stdout, stderr io.Writer) (*InstallToolResult, error) {
+	installer, ok := toolInstallers[toolName]
+	if !ok {
+		return nil, fmt.Errorf("no installer available for '%s'", toolName)
+	}
+
+	// Detect remote OS
+	osName, err := DetectRemoteOS(client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect remote OS: %w", err)
+	}
+
+	installCmd, ok := installer.Installers[osName]
+	if !ok {
+		return nil, fmt.Errorf("no installer for '%s' on %s", toolName, osName)
+	}
+
+	// Run the install command with streaming output
+	exitCode, err := client.ExecStream(installCmd, stdout, stderr)
+	if err != nil {
+		return &InstallToolResult{
+			Success: false,
+			Output:  fmt.Sprintf("installation command failed: %v", err),
+		}, nil
+	}
+
+	if exitCode != 0 {
+		return &InstallToolResult{
+			Success: false,
+			Output:  fmt.Sprintf("installation exited with code %d", exitCode),
+		}, nil
+	}
+
+	return &InstallToolResult{
+		Success:       true,
+		PathAdditions: installer.PathAdditions,
+	}, nil
+}
+
+// GetInstallCommandDescription returns a human-readable description of what
+// will be run to install a tool.
+func GetInstallCommandDescription(toolName, osName string) string {
+	installer, ok := toolInstallers[toolName]
+	if !ok {
+		return ""
+	}
+
+	cmd, ok := installer.Installers[osName]
+	if !ok {
+		return ""
+	}
+
+	// Simplify the command for display
+	// Just show the main package manager command
+	if strings.Contains(cmd, "brew install") {
+		return "brew install " + toolName
+	}
+	if strings.Contains(cmd, "apt-get install") {
+		return "apt-get install " + toolName
+	}
+	if strings.Contains(cmd, "rustup.rs") {
+		return "rustup (official installer)"
+	}
+	if strings.Contains(cmd, "xcode-select") {
+		return "xcode-select --install"
+	}
+	if strings.Contains(cmd, "nodesource") {
+		return "nodesource + apt-get install nodejs"
+	}
+
+	// Fallback: truncate if too long
+	if len(cmd) > 50 {
+		return cmd[:47] + "..."
+	}
+	return cmd
+}

--- a/internal/exec/provision_test.go
+++ b/internal/exec/provision_test.go
@@ -1,0 +1,123 @@
+package exec
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetToolInstaller(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		wantOk   bool
+	}{
+		{
+			name:     "go is supported",
+			toolName: "go",
+			wantOk:   true,
+		},
+		{
+			name:     "node is supported",
+			toolName: "node",
+			wantOk:   true,
+		},
+		{
+			name:     "npm is supported",
+			toolName: "npm",
+			wantOk:   true,
+		},
+		{
+			name:     "python is supported",
+			toolName: "python",
+			wantOk:   true,
+		},
+		{
+			name:     "cargo is supported",
+			toolName: "cargo",
+			wantOk:   true,
+		},
+		{
+			name:     "make is supported",
+			toolName: "make",
+			wantOk:   true,
+		},
+		{
+			name:     "unknown tool not supported",
+			toolName: "unknowntool123",
+			wantOk:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, ok := GetToolInstaller(tt.toolName)
+			assert.Equal(t, tt.wantOk, ok)
+			if ok {
+				assert.Equal(t, tt.toolName, installer.Name)
+			}
+		})
+	}
+}
+
+func TestCanInstallTool(t *testing.T) {
+	assert.True(t, CanInstallTool("go"))
+	assert.True(t, CanInstallTool("node"))
+	assert.True(t, CanInstallTool("python"))
+	assert.False(t, CanInstallTool("unknowntool"))
+}
+
+func TestToolInstaller_HasDarwinAndLinux(t *testing.T) {
+	// Verify all registered tools have both darwin and linux installers
+	for name, installer := range toolInstallers {
+		t.Run(name, func(t *testing.T) {
+			assert.NotEmpty(t, installer.Installers["darwin"], "missing darwin installer for %s", name)
+			assert.NotEmpty(t, installer.Installers["linux"], "missing linux installer for %s", name)
+		})
+	}
+}
+
+func TestGetInstallCommandDescription(t *testing.T) {
+	tests := []struct {
+		name     string
+		toolName string
+		osName   string
+		wantSub  string // expect description to contain this
+	}{
+		{
+			name:     "go on darwin",
+			toolName: "go",
+			osName:   "darwin",
+			wantSub:  "brew install",
+		},
+		{
+			name:     "cargo on linux",
+			toolName: "cargo",
+			osName:   "linux",
+			wantSub:  "rustup",
+		},
+		{
+			name:     "make on darwin",
+			toolName: "make",
+			osName:   "darwin",
+			wantSub:  "make", // Returns simplified description
+		},
+		{
+			name:     "unknown tool",
+			toolName: "unknowntool",
+			osName:   "darwin",
+			wantSub:  "", // should return empty
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desc := GetInstallCommandDescription(tt.toolName, tt.osName)
+			if tt.wantSub == "" {
+				assert.Empty(t, desc)
+			} else {
+				assert.Contains(t, desc, tt.wantSub)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When a command fails due to a missing tool on the remote machine, `rr` now offers interactive options to fix the issue:

- **Install the tool remotely** - supports common dev tools: `go`, `node`, `npm`, `python`, `pip`, `cargo`, `rust`, `make`, `git`
- **Add PATH export to .rr.yaml** - if the tool exists but isn't in the login shell's PATH
- **Skip** - continue without fixing

After fixing, users can optionally retry the failed command.

## User Experience

```
$ rr run 'make test'
...
make: go: No such file or directory

✗ 'go' not found in PATH on remote

  'go' wasn't found on the remote machine.
  ...

Would you like rr to fix this?
> Install 'go' on the remote machine
  Add PATH export to .rr.yaml
  Skip

Installing 'go' on m1...
  Running: brew install go
  [output...]
✓ Installed 'go' successfully

Retry the command? [Y/n]
```

## Changes

### New Files
- `internal/exec/provision.go` - Tool installation registry with platform-specific install commands (darwin/linux)
- `internal/config/update.go` - YAML-preserving config file updates for adding setup_commands
- `internal/cli/fix.go` - Interactive fix flow using charmbracelet/huh

### Modified Files  
- `internal/exec/executor.go` - Added `MissingToolError` struct and `DetectMissingTool()` for structured error handling
- `internal/cli/run.go` - Integrated interactive fix flow after detecting missing tool errors

## Test plan
- [ ] Run `rr run 'make test'` on a remote where `go` is not installed
- [ ] Verify interactive menu appears with all three options
- [ ] Test "Install" option - verify tool gets installed
- [ ] Test "Add PATH" option - verify .rr.yaml is updated correctly
- [ ] Test "Skip" option - verify clean exit
- [ ] Test retry flow after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)