### PR TITLE
fix(sync): expand ${HOME} to ~ for remote paths

### DIFF
--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -75,7 +75,7 @@ func RunTask(opts TaskOptions) (int, error) {
 	// Get remote directory for task execution
 	remoteDir := ""
 	if !wf.Conn.IsLocal {
-		remoteDir = config.Expand(wf.Conn.Host.Dir)
+		remoteDir = config.ExpandRemote(wf.Conn.Host.Dir)
 	}
 
 	// Execute the task

--- a/internal/config/expand_test.go
+++ b/internal/config/expand_test.go
@@ -1,0 +1,70 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExpandRemote(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "HOME expands to tilde",
+			input:    "${HOME}/rr/project",
+			expected: "~/rr/project",
+		},
+		{
+			name:     "PROJECT expands",
+			input:    "~/rr/${PROJECT}",
+			expected: "~/rr/" + getProject(), // Uses current project
+		},
+		{
+			name:     "USER expands",
+			input:    "/home/${USER}/rr",
+			expected: "/home/" + os.Getenv("USER") + "/rr",
+		},
+		{
+			name:     "tilde unchanged",
+			input:    "~/projects/app",
+			expected: "~/projects/app",
+		},
+		{
+			name:     "absolute path unchanged",
+			input:    "/opt/app/data",
+			expected: "/opt/app/data",
+		},
+		{
+			name:     "multiple variables",
+			input:    "${HOME}/rr/${PROJECT}",
+			expected: "~/rr/" + getProject(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ExpandRemote(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestExpand_vs_ExpandRemote(t *testing.T) {
+	// Expand should use local HOME
+	localHome, _ := os.UserHomeDir()
+	expandResult := Expand("${HOME}/test")
+	assert.Equal(t, localHome+"/test", expandResult)
+
+	// ExpandRemote should use ~ for remote shell expansion
+	expandRemoteResult := ExpandRemote("${HOME}/test")
+	assert.Equal(t, "~/test", expandRemoteResult)
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -141,9 +141,9 @@ func parseConfig(v *viper.Viper, path string) (*Config, error) {
 			"Check the YAML syntax in "+path+" - something's not parsing right.")
 	}
 
-	// Expand variables in host directories
+	// Expand variables in host directories (use ExpandRemote to preserve ~ for remote shell)
 	for name, host := range cfg.Hosts {
-		host.Dir = Expand(host.Dir)
+		host.Dir = ExpandRemote(host.Dir)
 		cfg.Hosts[name] = host
 	}
 

--- a/internal/doctor/remote.go
+++ b/internal/doctor/remote.go
@@ -30,7 +30,7 @@ func (c *RemoteDirCheck) Run() CheckResult {
 		}
 	}
 
-	dir := config.Expand(c.Dir)
+	dir := config.ExpandRemote(c.Dir)
 
 	// Check if directory exists
 	_, _, exitCode, err := c.Conn.Client.Exec(fmt.Sprintf("test -d %q", dir))
@@ -65,7 +65,7 @@ func (c *RemoteDirCheck) Fix() error {
 		return fmt.Errorf("no connection")
 	}
 
-	dir := config.Expand(c.Dir)
+	dir := config.ExpandRemote(c.Dir)
 	_, _, exitCode, err := c.Conn.Client.Exec(fmt.Sprintf("mkdir -p %q", dir))
 	if err != nil || exitCode != 0 {
 		return fmt.Errorf("failed to create directory: %s", dir)
@@ -93,7 +93,7 @@ func (c *RemoteWritePermCheck) Run() CheckResult {
 		}
 	}
 
-	dir := config.Expand(c.Dir)
+	dir := config.ExpandRemote(c.Dir)
 
 	// First check if dir exists
 	_, _, exitCode, _ := c.Conn.Client.Exec(fmt.Sprintf("test -d %q", dir))


### PR DESCRIPTION
## Summary

The `${HOME}` config variable was being expanded to the **local** machine's home directory instead of being preserved for the remote shell to expand. This caused files to sync to wrong paths like `/Users/rileyhilliard/rr/project` on remote Linux machines instead of `~/rr/project` (which expands to `/root/rr/project` on the remote).

**Root cause**: `config.Expand()` in `loader.go` was expanding `${HOME}` at config load time using `os.UserHomeDir()` from the local machine.

**Fix**: 
- Add `ExpandRemote()` that converts `${HOME}` to `~` for remote shell expansion
- Add `ensureRemoteDir()` to create remote directory before rsync (rsync doesn't create parent dirs)
- Add `shellQuotePreserveTilde()` to properly quote paths while keeping `~` unquoted so shells expand it

## Test plan
- [x] Added unit tests for `ExpandRemote()` 
- [x] Manual test: `rr run 'pwd'` now shows `/root/rr/project` on remote Linux instead of `/Users/local/rr/project`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)