### PR TITLE
fix(test): add linux_arm64 asset to TestFindAsset

### DIFF
--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -361,6 +361,7 @@ func TestFindAsset(t *testing.T) {
 			{Name: "rr_darwin_arm64.tar.gz", DownloadURL: "https://example.com/darwin_arm64"},
 			{Name: "rr_darwin_amd64.tar.gz", DownloadURL: "https://example.com/darwin_amd64"},
 			{Name: "rr_linux_amd64.tar.gz", DownloadURL: "https://example.com/linux_amd64"},
+			{Name: "rr_linux_arm64.tar.gz", DownloadURL: "https://example.com/linux_arm64"},
 			{Name: "rr_windows_amd64.zip", DownloadURL: "https://example.com/windows_amd64"},
 		},
 	}


### PR DESCRIPTION
## Summary
The `TestFindAsset` test was missing `linux_arm64` in the mock assets, causing it to fail on ARM64 Linux machines (like Apple Silicon Mac remotes running Linux VMs).

## Test plan
- [x] Test passes on linux/arm64 remote

🤖 Generated with [Claude Code](https://claude.com/claude-code)