### PR TITLE
fix(cli): display host name instead of IP in status output

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -105,7 +105,7 @@ func Run(opts RunOptions) (int, error) {
 					if fixResult != nil && fixResult.ShouldRetry {
 						// User wants to retry - show final status then indicate retry
 						wf.PhaseDisplay.ThinDivider()
-						renderFinalStatus(wf.PhaseDisplay, exitCode, time.Since(wf.StartTime), execDuration, wf.Conn.Alias)
+						renderFinalStatus(wf.PhaseDisplay, exitCode, time.Since(wf.StartTime), execDuration, wf.Conn.Name)
 
 						// Close current workflow and retry
 						wf.Close()
@@ -143,7 +143,7 @@ func Run(opts RunOptions) (int, error) {
 
 	// Show final status
 	wf.PhaseDisplay.ThinDivider()
-	renderFinalStatus(wf.PhaseDisplay, exitCode, time.Since(wf.StartTime), execDuration, wf.Conn.Alias)
+	renderFinalStatus(wf.PhaseDisplay, exitCode, time.Since(wf.StartTime), execDuration, wf.Conn.Name)
 
 	return exitCode, nil
 }


### PR DESCRIPTION
## Summary
- Show the human-readable host name from config (e.g., "m4") instead of the SSH alias/IP address (e.g., "192.168.86.29") in completion and failure messages
- Makes output more meaningful when working with multiple hosts

## Test plan
- [x] Existing tests pass
- [x] Manual verification: `rr run 'echo hello'` shows "Completed on m4" instead of "Completed on 192.168.86.29"

🤖 Generated with [Claude Code](https://claude.com/claude-code)