### PR TITLE
fix(ui): slow down fake progress bar to 30 seconds

### DIFF
--- a/internal/ui/inline_progress.go
+++ b/internal/ui/inline_progress.go
@@ -48,7 +48,7 @@ func (p *InlineProgress) SetUseFakeProgress(use bool) {
 }
 
 // fakeProgressDuration is how long the fake progress takes to reach 99%.
-const fakeProgressDuration = 10 * time.Second
+const fakeProgressDuration = 30 * time.Second
 
 // easeOutQuad applies an ease-out quadratic curve: decelerates toward the end.
 // t should be in range [0, 1], returns value in [0, 1].

--- a/internal/ui/inline_progress_test.go
+++ b/internal/ui/inline_progress_test.go
@@ -181,11 +181,11 @@ func TestEaseOutQuad(t *testing.T) {
 func TestFakeProgressCapsAt99(t *testing.T) {
 	var buf bytes.Buffer
 	p := NewInlineProgress("Test", &buf)
-	p.startTime = time.Now().Add(-15 * time.Second) // 15 seconds ago
+	p.startTime = time.Now().Add(-35 * time.Second) // 35 seconds ago
 
 	fake := p.calculateFakeProgress()
 
-	// After 10+ seconds, should cap at 99%
+	// After 30+ seconds, should cap at 99%
 	assert.Equal(t, 0.99, fake)
 }
 


### PR DESCRIPTION
## Summary
- Increase fake progress duration from 10s to 30s to reach 99%
- The ease-out curve already provides faster-at-start, slower-at-end behavior
- Feels more natural for longer sync operations

## Test plan
- [x] Unit tests updated and pass
- [x] Manual test: start a sync and observe progress bar timing

🤖 Generated with [Claude Code](https://claude.com/claude-code)