### PR TITLE
Change video source to local file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rr (Road Runner)
 
 <p align="center">
-  <video src="https://github.com/rileyhilliard/rr/raw/main/assets/rr.mp4" controls width="600"></video>
+  <video src="assets/rr.mp4" controls width="600"></video>
 </p>
 
 [![CI](https://github.com/rileyhilliard/rr/actions/workflows/ci.yml/badge.svg)](https://github.com/rileyhilliard/rr/actions/workflows/ci.yml)
@@ -22,7 +22,7 @@ rr run "make test"
 This rsyncs your project to the remote host, runs `make test`, and streams the output back. If you switch from your home LAN to a VPN, it figures out which hostname works. If someone else is using the machine, it waits for them to finish.
 
 <p align="center">
-  <video src="https://github.com/rileyhilliard/rr/raw/main/assets/rr.mp4" controls width="600"></video>
+  <video src="assets/rr.mp4" controls width="600"></video>
 </p>
 
 ## Quick start


### PR DESCRIPTION
Updated video source path in README.md to local assets.

## What

Brief description of what this PR does.

## Why

Why is this change needed? Link to issue if applicable.

## How

How does this change work? Any important implementation details?

## Testing

How did you test this change?

- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Manual testing (describe what you tested)

## Checklist

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I've updated documentation if needed
- [ ] I've added tests for new functionality
