### PR TITLE
Update README to use image instead of video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # rr (Road Runner)
 
 <p align="center">
-  <video src="assets/rr.mp4" controls width="600"></video>
+ 
+![rr](https://github.com/user-attachments/assets/d0ba88a9-6220-49ad-87eb-a06b234fbfb5)
+
 </p>
 
 [![CI](https://github.com/rileyhilliard/rr/actions/workflows/ci.yml/badge.svg)](https://github.com/rileyhilliard/rr/actions/workflows/ci.yml)


### PR DESCRIPTION
Replaced video tag with an image link in README.

## What

Brief description of what this PR does.

## Why

Why is this change needed? Link to issue if applicable.

## How

How does this change work? Any important implementation details?

## Testing

How did you test this change?

- [ ] Unit tests pass (`make test`)
- [ ] Lint passes (`make lint`)
- [ ] Manual testing (describe what you tested)

## Checklist

- [ ] I've read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] I've updated documentation if needed
- [ ] I've added tests for new functionality
