### PR TITLE
fix: source .bashrc/.zshrc for proper PATH in remote commands

### DIFF
--- a/internal/exec/task_test.go
+++ b/internal/exec/task_test.go
@@ -333,8 +333,11 @@ func TestBuildRemoteCommand_DefaultShell(t *testing.T) {
 	}
 	result := BuildRemoteCommand("make test", host)
 
-	// Should use user's default shell with login mode
-	assert.Contains(t, result, "${SHELL:-/bin/sh} -l -c")
+	// Should use user's default shell
+	assert.Contains(t, result, "${SHELL:-/bin/bash} -c")
+	// Should source rc files for PATH setup
+	assert.Contains(t, result, "[ -f ~/.bashrc ]")
+	assert.Contains(t, result, "[ -f ~/.zshrc ]")
 	assert.Contains(t, result, "make test")
 }
 
@@ -357,7 +360,7 @@ func TestBuildRemoteCommand_SetupCommands(t *testing.T) {
 	}
 	result := BuildRemoteCommand("go test", host)
 
-	// Should include setup command before main command
-	assert.Contains(t, result, "export PATH=/opt/go/bin:$PATH")
+	// Should include setup command before main command ($ is escaped to prevent outer shell expansion)
+	assert.Contains(t, result, "export PATH=/opt/go/bin:\\$PATH")
 	assert.Contains(t, result, "go test")
 }


### PR DESCRIPTION
## Summary

- Source ~/.bashrc and ~/.zshrc before running remote commands to ensure tools like bun, nvm, pyenv are available
- Escape $ characters in commands so variables are evaluated inside the shell, not by the outer shell

## Problem

SSH non-interactive sessions don't source rc files, so PATH modifications from tools like bun, nvm, and pyenv weren't available. Users had to manually add PATH boilerplate to their setup_commands.

## Test plan

- [x] Verified `rr run 'which bun'` now finds bun on remote
- [x] All unit tests pass
- [x] Linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)