### PR TITLE
feat: add unlock command and improve lock/signal handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ rr status               # Show connection and sync status
 rr host list            # List configured hosts
 rr host add             # Add a new host interactively
 rr host remove mini     # Remove a host from config
+rr unlock               # Release a stuck lock on the default host
+rr unlock --all         # Release locks on all configured hosts
 rr update               # Update rr to latest version
 rr update --check       # Just check if update is available
 rr completion bash      # Shell completions (also zsh, fish, powershell)
@@ -193,11 +195,15 @@ sync:
 
 **Lock stuck?**
 
-If a previous run crashed and left a lock:
+If a previous run crashed or lost connection and left a lock behind:
 
 ```bash
-rr run --force-unlock "your command"
+rr unlock              # Release lock on default host
+rr unlock gpu-box      # Release lock on specific host
+rr unlock --all        # Release locks on all hosts
 ```
+
+The lock is project-specific, so this only affects the current directory's project.
 
 For more, see the [troubleshooting guide](docs/troubleshooting.md).
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -289,12 +289,23 @@ rr doctor
 # Look for "stale locks" in the output
 ```
 
-**Force release a stale lock:**
+**Release a stuck lock:**
 
 ```bash
-# Manually remove the lock directory on remote
-rr exec "rm -rf /tmp/rr-locks/myproject.lock"
+rr unlock              # Release lock on default host
+rr unlock gpu-box      # Release lock on specific host
+rr unlock --all        # Release locks on all configured hosts
 ```
+
+The lock is project-specific (based on your current directory), so this only affects locks for your project.
+
+**When do locks get stuck?**
+
+- Process crashed or was killed (Ctrl+C during lock phase)
+- Network disconnected during a run
+- SSH connection dropped unexpectedly
+
+Stale locks are automatically cleaned up after the configured `stale` duration (default: 1 hour), but you can use `rr unlock` if you need to release one immediately.
 
 **Increase lock timeout** for long-running commands:
 

--- a/internal/cli/unlock.go
+++ b/internal/cli/unlock.go
@@ -1,0 +1,244 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/huh"
+	"github.com/rileyhilliard/rr/internal/config"
+	"github.com/rileyhilliard/rr/internal/errors"
+	"github.com/rileyhilliard/rr/internal/host"
+	"github.com/rileyhilliard/rr/internal/lock"
+	"github.com/rileyhilliard/rr/internal/ui"
+)
+
+// UnlockOptions holds options for the unlock command.
+type UnlockOptions struct {
+	Host string // Specific host to unlock (empty for default or picker)
+	All  bool   // Unlock all configured hosts
+}
+
+// unlockCommand releases the lock on one or more remote hosts.
+func unlockCommand(opts UnlockOptions) error {
+	cfg, _, err := loadExistingConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(cfg.Hosts) == 0 {
+		return errors.New(errors.ErrConfig,
+			"No hosts configured",
+			"Add a host with 'rr host add' first.")
+	}
+
+	// Get current working directory for project hash
+	workDir, err := os.Getwd()
+	if err != nil {
+		return errors.WrapWithCode(err, errors.ErrExec,
+			"Can't determine current directory",
+			"Check your directory permissions.")
+	}
+	projectHash := hashProject(workDir)
+
+	// Determine which hosts to unlock
+	var hostsToUnlock []string
+
+	if opts.All {
+		// Unlock all configured hosts
+		for name := range cfg.Hosts {
+			hostsToUnlock = append(hostsToUnlock, name)
+		}
+		sort.Strings(hostsToUnlock)
+	} else if opts.Host != "" {
+		// Specific host provided
+		if _, exists := cfg.Hosts[opts.Host]; !exists {
+			var available []string
+			for k := range cfg.Hosts {
+				available = append(available, k)
+			}
+			sort.Strings(available)
+			return errors.New(errors.ErrConfig,
+				fmt.Sprintf("Host '%s' not found", opts.Host),
+				fmt.Sprintf("Available hosts: %s", strings.Join(available, ", ")))
+		}
+		hostsToUnlock = []string{opts.Host}
+	} else {
+		// No host specified - use default or show picker
+		if cfg.Default != "" {
+			hostsToUnlock = []string{cfg.Default}
+		} else if len(cfg.Hosts) == 1 {
+			// Only one host, use it
+			for name := range cfg.Hosts {
+				hostsToUnlock = []string{name}
+			}
+		} else {
+			// Multiple hosts, no default - show picker
+			selectedHost, err := pickHostForUnlock(cfg)
+			if err != nil {
+				return err
+			}
+			if selectedHost == "" {
+				fmt.Println("Cancelled.")
+				return nil
+			}
+			hostsToUnlock = []string{selectedHost}
+		}
+	}
+
+	// Process each host
+	var successCount, notLockedCount, failCount int
+
+	for _, hostName := range hostsToUnlock {
+		hostCfg := cfg.Hosts[hostName]
+		result := unlockHost(hostName, hostCfg, cfg.Lock, projectHash)
+
+		switch result {
+		case unlockResultSuccess:
+			successCount++
+		case unlockResultNotLocked:
+			notLockedCount++
+		case unlockResultFailed:
+			failCount++
+		}
+	}
+
+	// Summary for --all
+	if opts.All && len(hostsToUnlock) > 1 {
+		fmt.Println()
+		if successCount > 0 {
+			fmt.Printf("Released locks on %d host(s)\n", successCount)
+		}
+		if notLockedCount > 0 {
+			fmt.Printf("%d host(s) had no lock\n", notLockedCount)
+		}
+		if failCount > 0 {
+			fmt.Printf("%d host(s) failed\n", failCount)
+		}
+	}
+
+	if failCount > 0 {
+		return errors.New(errors.ErrLock,
+			"Some hosts failed to unlock",
+			"Check the SSH connection and try again.")
+	}
+
+	return nil
+}
+
+type unlockResult int
+
+const (
+	unlockResultSuccess unlockResult = iota
+	unlockResultNotLocked
+	unlockResultFailed
+)
+
+// unlockHost attempts to release the lock on a single host.
+func unlockHost(hostName string, hostCfg config.Host, lockCfg config.LockConfig, projectHash string) unlockResult {
+	if len(hostCfg.SSH) == 0 {
+		fmt.Printf("%s %s: no SSH connections configured\n", ui.SymbolFail, hostName)
+		return unlockResultFailed
+	}
+
+	// Build lock directory path
+	baseDir := lockCfg.Dir
+	if baseDir == "" {
+		baseDir = "/tmp"
+	}
+	lockDir := filepath.Join(baseDir, fmt.Sprintf("rr-%s.lock", projectHash))
+
+	// Try to connect using the first available SSH alias
+	spinner := ui.NewSpinner(fmt.Sprintf("Connecting to %s", hostName))
+	spinner.Start()
+
+	var conn *host.Connection
+	var connErr error
+	for _, sshAlias := range hostCfg.SSH {
+		client, latency, err := host.ProbeAndConnect(sshAlias, 10*time.Second)
+		if err == nil {
+			conn = &host.Connection{
+				Name:    hostName,
+				Alias:   sshAlias,
+				Client:  client,
+				Host:    hostCfg,
+				Latency: latency,
+			}
+			break
+		}
+		connErr = err
+	}
+
+	if conn == nil {
+		spinner.Fail()
+		fmt.Printf("  Could not connect: %v\n", connErr)
+		return unlockResultFailed
+	}
+	defer conn.Close()
+	spinner.Success()
+
+	// Check if lock exists
+	if !lock.IsLocked(conn, lockCfg, projectHash) {
+		fmt.Printf("%s %s: no lock held\n", ui.SymbolPending, hostName)
+		return unlockResultNotLocked
+	}
+
+	// Get lock holder info before releasing
+	holder := lock.GetLockHolder(conn, lockCfg, projectHash)
+
+	// Release the lock
+	err := lock.ForceRelease(conn, lockDir)
+	if err != nil {
+		fmt.Printf("%s %s: failed to release lock: %v\n", ui.SymbolFail, hostName, err)
+		return unlockResultFailed
+	}
+
+	if holder != "" && holder != "unknown" {
+		fmt.Printf("%s %s: lock released (was held by %s)\n", ui.SymbolSuccess, hostName, holder)
+	} else {
+		fmt.Printf("%s %s: lock released\n", ui.SymbolSuccess, hostName)
+	}
+	return unlockResultSuccess
+}
+
+// pickHostForUnlock shows a host picker for the unlock command.
+func pickHostForUnlock(cfg *config.Config) (string, error) {
+	var hostNames []string
+	for k := range cfg.Hosts {
+		hostNames = append(hostNames, k)
+	}
+	sort.Strings(hostNames)
+
+	options := make([]huh.Option[string], len(hostNames))
+	for i, h := range hostNames {
+		label := h
+		if h == cfg.Default {
+			label += " (default)"
+		}
+		if hostCfg, ok := cfg.Hosts[h]; ok && len(hostCfg.SSH) > 0 {
+			label += " - " + hostCfg.SSH[0]
+		}
+		options[i] = huh.NewOption(label, h)
+	}
+
+	var selected string
+	form := huh.NewForm(
+		huh.NewGroup(
+			huh.NewSelect[string]().
+				Title("Select host to unlock").
+				Options(options...).
+				Value(&selected),
+		),
+	)
+
+	if err := form.Run(); err != nil {
+		return "", errors.WrapWithCode(err, errors.ErrExec,
+			"Couldn't get your selection",
+			"Try again or use: rr unlock <host>")
+	}
+
+	return selected, nil
+}

--- a/internal/monitor/collector.go
+++ b/internal/monitor/collector.go
@@ -654,7 +654,7 @@ func parseDarwinLoadAvg(line string) [3]float64 {
 	return loadAvg
 }
 
-// parseDarwinMemory parses memory metrics from macOS vm_stat command output.
+// parseDarwinMemory parses memory metrics from macOS vm_stat and sysctl hw.memsize output.
 func parseDarwinMemory(vmStatOutput string) (*RAMMetrics, error) {
 	metrics := &RAMMetrics{}
 	scanner := bufio.NewScanner(strings.NewReader(vmStatOutput))
@@ -663,6 +663,7 @@ func parseDarwinMemory(vmStatOutput string) (*RAMMetrics, error) {
 
 	var pagesActive, pagesWired, pagesInactive, pagesSpeculative, pagesFree int64
 	var pagesCompressed, pagesPurgeable, pagesCached int64
+	var totalMemBytes int64
 
 	for scanner.Scan() {
 		line := scanner.Text()
@@ -678,6 +679,18 @@ func parseDarwinMemory(vmStatOutput string) (*RAMMetrics, error) {
 					if err == nil {
 						pageSize = size
 					}
+				}
+			}
+			continue
+		}
+
+		// Parse sysctl hw.memsize output: "hw.memsize: 17179869184"
+		if strings.HasPrefix(line, "hw.memsize:") {
+			parts := strings.Split(line, ":")
+			if len(parts) == 2 {
+				val, err := strconv.ParseInt(strings.TrimSpace(parts[1]), 10, 64)
+				if err == nil {
+					totalMemBytes = val
 				}
 			}
 			continue
@@ -721,14 +734,22 @@ func parseDarwinMemory(vmStatOutput string) (*RAMMetrics, error) {
 		return nil, fmt.Errorf("error scanning vm_stat output: %w", err)
 	}
 
-	usedPages := pagesActive + pagesWired + pagesCompressed + pagesSpeculative
-	availablePages := pagesFree + pagesInactive + pagesPurgeable
-	totalPages := usedPages + availablePages + pagesInactive
+	// Used = active + wired + compressed (speculative is part of free)
+	usedPages := pagesActive + pagesWired + pagesCompressed
+	// Available = free + inactive + purgeable + speculative (memory that can be reclaimed)
+	availablePages := pagesFree + pagesInactive + pagesPurgeable + pagesSpeculative
 
 	metrics.UsedBytes = usedPages * pageSize
-	metrics.TotalBytes = totalPages * pageSize
 	metrics.Available = availablePages * pageSize
 	metrics.Cached = pagesCached * pageSize
+
+	// Use sysctl hw.memsize for accurate total, fall back to calculation if not available
+	if totalMemBytes > 0 {
+		metrics.TotalBytes = totalMemBytes
+	} else {
+		// Fallback: estimate from page counts (less accurate)
+		metrics.TotalBytes = (usedPages + availablePages) * pageSize
+	}
 
 	return metrics, nil
 }

--- a/internal/monitor/graphs.go
+++ b/internal/monitor/graphs.go
@@ -155,31 +155,17 @@ func RenderBrailleSparkline(data []float64, width, height int, baseColor lipglos
 		}
 	}
 
-	// Convert grid to string with per-column coloring
+	// Convert grid to string with per-column coloring based on data values
 	var lines []string
-	for rowIdx, row := range grid {
+	for _, row := range grid {
 		var lineBuilder strings.Builder
 		for colIdx, char := range row {
-			// Determine color based on value at this column
+			// Determine color based on max value at this column
 			var color lipgloss.Color
 			if isPercentage {
 				color = MetricColor(colMaxValues[colIdx])
 			} else {
 				color = baseColor
-			}
-
-			// For rows near the top, use the threshold color of the row height
-			// This creates a gradient effect where higher parts of the graph are more red
-			if isPercentage && char != brailleBase {
-				// Calculate what percentage this row represents
-				rowFromBottom := height - 1 - rowIdx
-				rowPercent := float64(rowFromBottom+1) / float64(height) * 100
-				// Blend between column value color and row threshold color
-				rowColor := MetricColor(rowPercent)
-				// Use the more severe color
-				if colorSeverity(rowColor) > colorSeverity(color) {
-					color = rowColor
-				}
 			}
 
 			// Apply both foreground and background color
@@ -190,18 +176,6 @@ func RenderBrailleSparkline(data []float64, width, height int, baseColor lipglos
 	}
 
 	return strings.Join(lines, "\n")
-}
-
-// colorSeverity returns a numeric severity for color comparison (higher = more severe)
-func colorSeverity(c lipgloss.Color) int {
-	switch c {
-	case ColorCritical:
-		return 2
-	case ColorWarning:
-		return 1
-	default:
-		return 0
-	}
 }
 
 // RenderMiniSparkline renders a single-row sparkline using block characters.

--- a/internal/monitor/styles_test.go
+++ b/internal/monitor/styles_test.go
@@ -123,8 +123,10 @@ func TestCompactProgressBar(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := CompactProgressBar(tt.width, tt.percent)
 			assert.NotEmpty(t, result)
-			// Should NOT contain brackets
-			assert.NotContains(t, result, "[")
+			// Should NOT contain decorative brackets (but may have ANSI escape codes)
+			assert.NotContains(t, result, "[█")
+			assert.NotContains(t, result, "[░")
+			assert.NotContains(t, result, "]")
 		})
 	}
 }

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -132,7 +132,9 @@ func BuildArgs(conn *host.Connection, localDir string, cfg config.SyncConfig) ([
 	// ControlPath uses a hash of the host to create unique socket files.
 	// ControlMaster=auto: reuse existing socket or create new one if needed.
 	// ControlPersist=60: keep the socket alive for 60s after last use.
-	sshCmd := fmt.Sprintf("ssh -o ControlMaster=auto -o ControlPath=%s/%%h-%%p -o ControlPersist=60",
+	// BatchMode=yes: prevent SSH from prompting for input (passwords, host keys, etc.)
+	//   which would cause rsync to hang since there's no terminal attached.
+	sshCmd := fmt.Sprintf("ssh -o ControlMaster=auto -o ControlPath=%s/%%h-%%p -o ControlPersist=60 -o BatchMode=yes",
 		controlSocketDir)
 	args = append(args, "-e", sshCmd)
 


### PR DESCRIPTION
## Summary
- Add new `unlock` command for manually releasing stale locks
- Improve signal handling with proper cleanup on Ctrl+C
- Fix SSH BatchMode for rsync hang issue
- Add remote artifact cleanup when removing hosts
- Fix macOS memory calculation and braille sparkline coloring

## Test plan
- [x] All existing tests pass
- [x] New tests added for unlock command and signal handling
- [x] Pre-push hooks validated (lint, test, coverage at 68.2%)