### PR TITLE
feat: add multi-host project support for load balancing

### DIFF
--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -143,14 +143,17 @@ func TestRunCommand_JoinsArgs(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Multiple args should be joined into single command
 	err = runCommand([]string{"make", "test"}, "", "", "")
 	require.Error(t, err)
-	// Should fail because no config, not because of args
-	assert.Contains(t, err.Error(), "config")
+	// Should fail on no hosts configured
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestRunCommand_ValidProbeTimeout(t *testing.T) {
@@ -158,13 +161,16 @@ func TestRunCommand_ValidProbeTimeout(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Valid probe timeout should not fail on parsing
 	err = runCommand([]string{"echo"}, "", "", "5s")
 	require.Error(t, err)
-	// Should fail on config, not on probe timeout
+	// Should fail on no hosts configured, not on probe timeout
 	assert.NotContains(t, err.Error(), "timeout")
 }
 
@@ -185,20 +191,26 @@ func TestExecCommand_JoinsArgs(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Multiple args should be joined
 	err = execCommand([]string{"ls", "-la"}, "", "", "")
 	require.Error(t, err)
-	// Should fail because no config, not because of args
-	assert.Contains(t, err.Error(), "config")
+	// Should fail on no hosts configured
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestExecCommand_ValidProbeTimeoutFormats(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
+
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
 
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
@@ -251,6 +263,9 @@ func TestRun_WithHostFlag(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
@@ -261,13 +276,16 @@ func TestRun_WithHostFlag(t *testing.T) {
 	})
 	assert.Equal(t, 1, exitCode)
 	require.Error(t, err)
-	// Should fail on config, but host flag was accepted
+	// Should fail on no hosts configured
 }
 
 func TestRun_WithTagFlag(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
+
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
 
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
@@ -357,6 +375,9 @@ func TestRun_SkipLockFlag(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
@@ -372,6 +393,9 @@ func TestRun_QuietMode(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
+
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
 
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
@@ -389,6 +413,9 @@ func TestRun_WorkingDirFlag(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
@@ -404,6 +431,9 @@ func TestRun_AllOptions(t *testing.T) {
 	tmpDir := t.TempDir()
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
+
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
 
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
@@ -421,8 +451,8 @@ func TestRun_AllOptions(t *testing.T) {
 	})
 	assert.Equal(t, 1, exitCode)
 	require.Error(t, err)
-	// All options accepted, fails on config
-	assert.Contains(t, err.Error(), "config")
+	// All options accepted, fails on no hosts configured
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestRunOptions_ZeroValues(t *testing.T) {
@@ -450,14 +480,17 @@ func TestRunCommand_MultipleArgsJoined(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	// Multiple args should be joined with spaces
 	err = runCommand([]string{"make", "test", "-v"}, "", "", "")
 	require.Error(t, err)
-	// Fails on config, but args were processed
-	assert.Contains(t, err.Error(), "config")
+	// Fails on no hosts configured, but args were processed
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestRunCommand_WithHostAndTag(t *testing.T) {
@@ -465,13 +498,16 @@ func TestRunCommand_WithHostAndTag(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	err = runCommand([]string{"echo"}, "myhost", "mytag", "")
 	require.Error(t, err)
-	// Should fail on config, flags were accepted
-	assert.Contains(t, err.Error(), "config")
+	// Should fail on no hosts configured, flags were accepted
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestExecCommand_MultipleArgsJoined(t *testing.T) {
@@ -479,13 +515,16 @@ func TestExecCommand_MultipleArgsJoined(t *testing.T) {
 	origDir, _ := os.Getwd()
 	defer os.Chdir(origDir)
 
+	// Isolate from real user config
+	t.Setenv("HOME", tmpDir)
+
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
 	err = execCommand([]string{"ls", "-la", "/tmp"}, "", "", "")
 	require.Error(t, err)
-	// Fails on config, but args were processed
-	assert.Contains(t, err.Error(), "config")
+	// Fails on no hosts configured, but args were processed
+	assert.Contains(t, err.Error(), "No hosts configured")
 }
 
 func TestMapProbeErrorToStatus_NilProbeError(t *testing.T) {
@@ -518,6 +557,9 @@ func TestRun_ProbeTimeoutValues(t *testing.T) {
 			origDir, _ := os.Getwd()
 			defer os.Chdir(origDir)
 
+			// Isolate from real user config
+			t.Setenv("HOME", tmpDir)
+
 			err := os.Chdir(tmpDir)
 			require.NoError(t, err)
 
@@ -527,8 +569,8 @@ func TestRun_ProbeTimeoutValues(t *testing.T) {
 			})
 			assert.Equal(t, 1, exitCode)
 			require.Error(t, err)
-			// Should fail on config, not probe timeout
-			assert.Contains(t, err.Error(), "config")
+			// Should fail on no hosts configured, not probe timeout
+			assert.Contains(t, err.Error(), "No hosts configured")
 		})
 	}
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -33,7 +33,8 @@ type GlobalDefaults struct {
 // This is shareable with the team and doesn't contain host connection details.
 type Config struct {
 	Version int                   `yaml:"version" mapstructure:"version"`
-	Host    string                `yaml:"host,omitempty" mapstructure:"host"`
+	Host    string                `yaml:"host,omitempty" mapstructure:"host"`   // Single host reference (backwards compat)
+	Hosts   []string              `yaml:"hosts,omitempty" mapstructure:"hosts"` // Multiple host references for load balancing
 	Sync    SyncConfig            `yaml:"sync" mapstructure:"sync"`
 	Lock    LockConfig            `yaml:"lock" mapstructure:"lock"`
 	Tasks   map[string]TaskConfig `yaml:"tasks" mapstructure:"tasks"`

--- a/internal/doctor/config_test.go
+++ b/internal/doctor/config_test.go
@@ -20,13 +20,11 @@ func TestConfigFileCheck(t *testing.T) {
 	})
 
 	t.Run("config found", func(t *testing.T) {
-		// Create a config file
+		// Create a config file (project config - hosts are now in global config)
 		cfgPath := filepath.Join(tmpDir, ".rr.yaml")
 		content := `version: 1
 hosts:
-  test:
-    ssh: ["test-host"]
-    dir: "~/test"
+  - test-host
 `
 		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
 			t.Fatal(err)
@@ -58,9 +56,7 @@ func TestConfigSchemaCheck(t *testing.T) {
 		cfgPath := filepath.Join(tmpDir, "valid.yaml")
 		content := `version: 1
 hosts:
-  test:
-    ssh: ["test-host"]
-    dir: "~/test"
+  - test-host
 `
 		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
 			t.Fatal(err)
@@ -179,9 +175,7 @@ func TestConfigReservedNamesCheck(t *testing.T) {
 		cfgPath := filepath.Join(tmpDir, "noreserved.yaml")
 		content := `version: 1
 hosts:
-  test:
-    ssh: ["test-host"]
-    dir: "~/test"
+  - test-host
 tasks:
   build:
     run: "make build"
@@ -202,9 +196,7 @@ tasks:
 		cfgPath := filepath.Join(tmpDir, "reserved.yaml")
 		content := `version: 1
 hosts:
-  test:
-    ssh: ["test-host"]
-    dir: "~/test"
+  - test-host
 tasks:
   run:
     run: "make run"

--- a/tests/integration/loadbalance_test.go
+++ b/tests/integration/loadbalance_test.go
@@ -26,13 +26,11 @@ func TestLoadBalancing_ConfigWaitTimeout(t *testing.T) {
 
 	t.Run("wait_timeout can be customized", func(t *testing.T) {
 		dir := t.TempDir()
+		// Project config (hosts are now in global config)
 		configContent := `
 version: 1
 hosts:
-  test-host:
-    ssh:
-      - localhost
-    dir: /tmp/test
+  - test-host
 lock:
   enabled: true
   wait_timeout: 2m30s

--- a/tests/integration/monitor_test.go
+++ b/tests/integration/monitor_test.go
@@ -31,10 +31,7 @@ func TestMonitorConfigParsing(t *testing.T) {
 		content := `
 version: 1
 hosts:
-  test-host:
-    ssh:
-      - test.local
-    dir: ~/projects/test
+  - test-host
 monitor:
   interval: 5s
   thresholds:
@@ -73,10 +70,7 @@ monitor:
 		content := `
 version: 1
 hosts:
-  test-host:
-    ssh:
-      - test.local
-    dir: ~/projects/test
+  - test-host
 monitor:
   interval: 3s
 `


### PR DESCRIPTION
## Summary

- Add `hosts:` (plural) field to project config for load balancing across multiple hosts
- When a host is locked, the system tries other hosts from the project's allowed list
- Empty hosts list = use all global hosts (backwards compatible)
- Init wizard now uses multi-select for choosing hosts
- Resolution priority: --host flag > project.Hosts > project.Host > all global hosts

## Changes

- `internal/config/types.go`: Add `Hosts []string` field
- `internal/config/loader.go`: Create `ResolveHosts()` function with priority order
- `internal/config/validate.go`: Add validation for hosts list
- `internal/cli/init.go`: Multi-select host picker
- `internal/cli/workflow.go`: Use resolved hosts for load balancing
- Tests updated with proper HOME isolation

## Test plan

- [x] `make verify` passes (lint + tests)
- [x] New projects generate `hosts:` list format
- [x] Existing `host:` (singular) projects still work
- [x] Load balancing respects project's allowed hosts

🤖 Generated with [Claude Code](https://claude.com/claude-code)