### PR TITLE
docs: update for global host config and add claude code plugin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "rr-cli",
+  "version": "1.0.0",
+  "description": "Teaches Claude how to use the rr (Road Runner) CLI for syncing code and running commands on remote machines.",
+  "author": "rileyhilliard",
+  "repository": "https://github.com/rileyhilliard/rr",
+  "license": "MIT",
+  "skills": ["skills/rr"]
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,14 @@ return errors.WrapWithCode(err, errors.ErrSSH, "connection failed", "Check if ho
 - Integration tests use env vars: `RR_TEST_SSH_HOST`, `RR_TEST_SSH_KEY`, `RR_TEST_SSH_USER`
 - Use `./scripts/ci-ssh-server.sh` for Docker-based SSH testing
 
-## Config File
+## Config Files
 
-The tool uses `.rr.yaml` in project root. Key sections: `hosts` (SSH connection details), `sync` (exclude/preserve patterns), `lock` (timeout settings), `tasks` (named commands).
+The tool uses two config files:
+
+- **Global config** (`~/.rr/config.yaml`): Host definitions (SSH connections, directories, tags, env vars). Personal settings not shared with team.
+- **Project config** (`.rr.yaml` in project root): Shareable settings including host references, sync rules, lock settings, tasks.
+
+Key sections in project config: `host`/`hosts` (references to global hosts), `sync` (exclude/preserve patterns), `lock` (timeout settings), `tasks` (named commands).
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ rr build
 
 ## Config
 
-The `.rr.yaml` file lives in your project root:
+`rr` uses two config files:
+
+**Global config** (`~/.rr/config.yaml`) - Your personal host definitions, not shared with team:
 
 ```yaml
 version: 1
@@ -119,7 +121,18 @@ hosts:
             - mac-mini-tailscale # Fall back to VPN
         dir: ${HOME}/projects/${PROJECT}
 
-default: mini
+defaults:
+    host: mini
+```
+
+**Project config** (`.rr.yaml` in project root) - Shareable settings for your project:
+
+```yaml
+version: 1
+
+# Reference hosts from global config (optional - uses all hosts if omitted)
+hosts:
+    - mini
 
 sync:
     exclude:
@@ -137,6 +150,7 @@ See [docs/configuration.md](docs/configuration.md) for all options.
 1. **Smart connection failover**: `rr` tries SSH connections in order and picks the first one that's reachable AND not busy. This handles three scenarios automatically:
 
     ```yaml
+    # ~/.rr/config.yaml
     hosts:
         gpu-box:
             ssh:
@@ -213,6 +227,16 @@ The lock is project-specific, so this only affects the current directory's proje
 
 For more, see the [troubleshooting guide](docs/troubleshooting.md).
 
+## Claude Code integration
+
+If you use [Claude Code](https://claude.ai/code), install the rr plugin to teach Claude how to use the CLI:
+
+```bash
+claude /plugin install rileyhilliard/rr
+```
+
+Claude will then understand rr commands, the two-config system, and can help with setup and troubleshooting. See [docs/claude-code.md](docs/claude-code.md) for details.
+
 ## Docs
 
 -   [SSH setup guide](docs/ssh-setup.md) - Get passwordless SSH working
@@ -221,6 +245,7 @@ For more, see the [troubleshooting guide](docs/troubleshooting.md).
 -   [Migration guide](docs/MIGRATION.md)
 -   [Example configs](docs/examples/)
 -   [Architecture](docs/ARCHITECTURE.md)
+-   [Claude Code plugin](docs/claude-code.md) - AI-assisted rr usage
 -   [Contributing](CONTRIBUTING.md)
 
 ## License

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -134,9 +134,36 @@ If you're upgrading from early pre-release versions, here's what changed:
 
 ### Config changes
 
+**Hosts moved to global config**
+
+Host definitions now live in `~/.rr/config.yaml` (global) instead of `.rr.yaml` (per-project). This allows you to commit `.rr.yaml` to version control without including personal SSH settings.
+
+```yaml
+# Before: hosts in .rr.yaml (per-project)
+# After: hosts in ~/.rr/config.yaml (global)
+```
+
+Move your `hosts:` section from `.rr.yaml` to `~/.rr/config.yaml`. Your project's `.rr.yaml` now references hosts by name:
+
+```yaml
+# ~/.rr/config.yaml (global - not shared)
+version: 1
+hosts:
+  mini:
+    ssh: [mini-local, mini-tailscale]
+    dir: ~/projects/${PROJECT}
+
+# .rr.yaml (project - can be committed)
+version: 1
+host: mini   # Reference to global host
+sync:
+  exclude:
+    - .git/
+```
+
 **Schema version added**
 
-Add `version: 1` at the top of your `.rr.yaml`:
+Add `version: 1` at the top of both config files:
 
 ```yaml
 # Before (v0.x)
@@ -144,12 +171,13 @@ hosts:
   mini:
     ssh: [mini-local]
 
-# After (v1.x)
+# After (v1.x) in ~/.rr/config.yaml
 version: 1
 
 hosts:
   mini:
     ssh: [mini-local]
+    dir: ~/projects/${PROJECT}
 ```
 
 **Host SSH field is now a list**

--- a/docs/claude-code.md
+++ b/docs/claude-code.md
@@ -1,0 +1,78 @@
+# Claude Code plugin
+
+The rr plugin teaches [Claude Code](https://claude.ai/code) how to use the rr CLI, including commands, configuration, and troubleshooting.
+
+## Install
+
+```bash
+claude /plugin install rileyhilliard/rr
+```
+
+## What it does
+
+Once installed, Claude understands:
+
+- **Commands**: `rr run`, `rr exec`, `rr sync`, `rr doctor`, `rr monitor`, and all subcommands
+- **Two-config system**: Global hosts at `~/.rr/config.yaml`, project settings at `.rr.yaml`
+- **Workflows**: Initial setup, daily development, multi-host load balancing
+- **Troubleshooting**: Connection issues, slow syncs, stuck locks
+
+## Usage
+
+The plugin activates automatically when you ask about remote development, running commands on remote machines, or mention rr specifically.
+
+**Examples:**
+
+```
+How do I set up rr for this project?
+Run the tests on my remote machine
+Why is rr failing to connect?
+Add a new host to my rr config
+```
+
+You can also invoke it directly:
+
+```
+/rr
+```
+
+## Alternative installation
+
+### Personal skill (without plugin)
+
+Copy the skill to your personal Claude skills directory:
+
+```bash
+cp -r /path/to/rr/skills/rr ~/.claude/skills/
+```
+
+### Project-level
+
+When working in the rr repository, the skill is automatically available.
+
+## What Claude learns
+
+| Topic | Coverage |
+|-------|----------|
+| Commands | All CLI commands with flags and examples |
+| Configuration | Global vs project config, all fields, variable expansion |
+| Host management | Adding, removing, listing hosts |
+| Sync | Exclude/preserve patterns, rsync flags |
+| Locking | How distributed locks work, unlocking stuck locks |
+| Tasks | Defining and running named tasks |
+| Load balancing | Multi-host setup, failover behavior |
+| Troubleshooting | Common issues and fixes |
+
+## Updating
+
+To get the latest version of the plugin:
+
+```bash
+claude /plugin update rileyhilliard/rr
+```
+
+## Uninstalling
+
+```bash
+claude /plugin uninstall rileyhilliard/rr
+```

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -1,41 +1,71 @@
 # Example configurations
 
-These are example `.rr.yaml` configurations for common project types.
+These are example configurations for common project types. `rr` uses two config files:
+
+- **Global config** (`~/.rr/config.yaml`) - Your personal host definitions (not shared)
+- **Project config** (`.rr.yaml`) - Shareable project settings
 
 ## Available examples
+
+### Project configs (copy to your project as `.rr.yaml`)
 
 | Example | Description |
 |---------|-------------|
 | [python-project.yaml](python-project.yaml) | Python project with pytest, mypy, ruff |
 | [go-project.yaml](go-project.yaml) | Go project with tests and linting |
 | [node-project.yaml](node-project.yaml) | Node.js/TypeScript project with Jest |
-| [multi-host.yaml](multi-host.yaml) | Multi-host setup with tags for team use |
+| [multi-host.yaml](multi-host.yaml) | Multi-host setup with load balancing |
+
+### Global config (copy to `~/.rr/config.yaml`)
+
+| Example | Description |
+|---------|-------------|
+| [global-config.yaml](global-config.yaml) | Example host definitions for all project types |
 
 ## Using an example
 
-1. Copy the example to your project root:
-   ```bash
-   cp docs/examples/python-project.yaml .rr.yaml
-   ```
+**1. Set up your global config** (one-time, if you haven't already)
 
-2. Update the host SSH aliases to match your setup:
-   ```yaml
-   hosts:
-     build-box:
-       ssh:
-         - your-host.local      # Your actual hostname
-         - your-host-tailscale  # Your VPN alias
-   ```
+Either use the interactive command:
+```bash
+rr host add
+```
 
-3. Test the connection:
-   ```bash
-   rr doctor
-   ```
+Or copy the example to your home directory:
+```bash
+mkdir -p ~/.rr
+cp docs/examples/global-config.yaml ~/.rr/config.yaml
+```
 
-4. Run a command:
-   ```bash
-   rr run "make test"
-   ```
+Then update the SSH aliases to match your actual hosts.
+
+**2. Copy a project config to your project**
+
+```bash
+cd your-project
+cp docs/examples/python-project.yaml .rr.yaml
+```
+
+**3. Update the host reference**
+
+Edit `.rr.yaml` and change the `host:` field to match a host name from your global config:
+
+```yaml
+# Reference a host from ~/.rr/config.yaml
+host: your-host-name
+```
+
+**4. Test the connection**
+
+```bash
+rr doctor
+```
+
+**5. Run a command**
+
+```bash
+rr run "make test"
+```
 
 ## Customizing
 
@@ -45,3 +75,4 @@ All examples use sensible defaults. Common customizations:
 - **Add preserve patterns** for dependencies installed on remote
 - **Define tasks** for commands you run frequently
 - **Adjust lock timeout** for longer-running operations
+- **Add multiple hosts** for load balancing across machines

--- a/docs/examples/global-config.yaml
+++ b/docs/examples/global-config.yaml
@@ -1,0 +1,76 @@
+# Example: Global config for host definitions
+#
+# This is a GLOBAL config (~/.rr/config.yaml) that defines your personal hosts.
+# This file is NOT shared with your team - each developer has their own.
+#
+# Hosts defined here can be referenced by name in any project's .rr.yaml file.
+
+version: 1
+
+hosts:
+  # Simple single-machine setup for Python/Go/Node projects
+  build-box:
+    ssh:
+      - build.local          # Try local network first
+      - build-tailscale      # Fall back to Tailscale
+    dir: ${HOME}/projects/${PROJECT}
+    env:
+      PYTHONDONTWRITEBYTECODE: "1"
+
+  # Linux server for Go cross-compilation
+  linux-box:
+    ssh:
+      - linux.local
+      - linux-vpn
+    dir: ${HOME}/code/${PROJECT}
+    env:
+      GOOS: linux
+      GOARCH: amd64
+      CGO_ENABLED: "0"
+
+  # Node.js development server
+  dev-server:
+    ssh:
+      - dev.local
+      - dev-tailscale
+    dir: ${HOME}/projects/${PROJECT}
+    env:
+      NODE_ENV: development
+
+  # Multi-host setup hosts
+  mac-mini:
+    ssh:
+      - mac-mini.local
+      - mac-mini-tailscale
+    dir: ${HOME}/builds/${PROJECT}
+    tags:
+      - fast
+      - macos
+      - gpu
+
+  linux-server:
+    ssh:
+      - linux-server.internal
+      - linux-tailscale
+    dir: /home/builds/${PROJECT}
+    tags:
+      - linux
+      - docker
+
+  raspberry-pi:
+    ssh:
+      - pi.local
+    dir: ${HOME}/projects/${PROJECT}
+    tags:
+      - arm
+      - linux
+
+defaults:
+  # Your default host when not specified
+  host: build-box
+
+  # Fall back to local if all remotes are down
+  local_fallback: true
+
+  # Longer timeout for flaky connections
+  probe_timeout: 5s

--- a/docs/examples/go-project.yaml
+++ b/docs/examples/go-project.yaml
@@ -1,22 +1,16 @@
 # Example: Go project
 #
-# This config is for a Go project that builds and tests on a remote Linux
-# machine (useful when developing on macOS but deploying to Linux).
+# This is a PROJECT config (.rr.yaml) for a Go project that builds and tests
+# on a remote Linux machine (useful when developing on macOS but deploying to Linux).
+#
+# NOTE: Host definitions belong in your GLOBAL config (~/.rr/config.yaml).
+# See go-global.yaml for an example global config.
 
 version: 1
 
-hosts:
-  linux-box:
-    ssh:
-      - linux.local
-      - linux-vpn
-    dir: ${HOME}/code/${PROJECT}
-    env:
-      GOOS: linux
-      GOARCH: amd64
-      CGO_ENABLED: "0"
-
-default: linux-box
+# Reference the host from your global config
+# If omitted, all global hosts are available
+host: linux-box
 
 sync:
   exclude:

--- a/docs/examples/multi-host.yaml
+++ b/docs/examples/multi-host.yaml
@@ -1,51 +1,25 @@
 # Example: Multi-host setup with load balancing
 #
-# This config shows how to set up multiple hosts for load balancing and
-# targeting specific machines. Useful for small teams sharing build servers.
+# This is a PROJECT config (.rr.yaml) that shows how to reference multiple hosts
+# for load balancing and targeting specific machines. Useful for small teams
+# sharing build servers.
+#
+# NOTE: Host definitions belong in your GLOBAL config (~/.rr/config.yaml).
+# See multi-host-global.yaml for an example global config that pairs with this.
 #
 # With multiple hosts configured, rr automatically distributes work:
-# - Tries hosts in alphabetical order with non-blocking lock checks
+# - Tries hosts in order with non-blocking lock checks
 # - If a host is locked, immediately tries the next available host
 # - If all hosts are locked, waits and round-robins until one is free
 
 version: 1
 
+# Reference hosts from your global config for load balancing
+# If omitted, all global hosts are used
 hosts:
-  mac-mini:
-    ssh:
-      - mac-mini.local
-      - mac-mini-tailscale
-    dir: ${HOME}/builds/${PROJECT}
-    tags:
-      - fast
-      - macos
-      - gpu
-
-  linux-server:
-    ssh:
-      - linux-server.internal
-      - linux-tailscale
-    dir: /home/builds/${PROJECT}
-    tags:
-      - linux
-      - docker
-
-  raspberry-pi:
-    ssh:
-      - pi.local
-    dir: ${HOME}/projects/${PROJECT}
-    tags:
-      - arm
-      - linux
-
-# Default to the fastest machine
-default: mac-mini
-
-# Fall back to local if all remotes are down
-local_fallback: true
-
-# Longer timeout for flaky connections
-probe_timeout: 5s
+  - mac-mini
+  - linux-server
+  - raspberry-pi
 
 sync:
   exclude:

--- a/docs/examples/node-project.yaml
+++ b/docs/examples/node-project.yaml
@@ -1,19 +1,16 @@
 # Example: Node.js/TypeScript project
 #
-# This config is for a Node.js project using npm/yarn and Jest for testing.
+# This is a PROJECT config (.rr.yaml) for a Node.js project using npm/yarn
+# and Jest for testing.
+#
+# NOTE: Host definitions belong in your GLOBAL config (~/.rr/config.yaml).
+# See node-global.yaml for an example global config.
 
 version: 1
 
-hosts:
-  dev-server:
-    ssh:
-      - dev.local
-      - dev-tailscale
-    dir: ${HOME}/projects/${PROJECT}
-    env:
-      NODE_ENV: development
-
-default: dev-server
+# Reference the host from your global config
+# If omitted, all global hosts are available
+host: dev-server
 
 sync:
   exclude:

--- a/docs/examples/python-project.yaml
+++ b/docs/examples/python-project.yaml
@@ -1,20 +1,16 @@
 # Example: Python project with pytest
 #
-# This config is for a typical Python project that runs tests on a remote
-# machine with more CPU/RAM than your laptop.
+# This is a PROJECT config (.rr.yaml) for a typical Python project that runs
+# tests on a remote machine with more CPU/RAM than your laptop.
+#
+# NOTE: Host definitions belong in your GLOBAL config (~/.rr/config.yaml).
+# See python-global.yaml for an example global config.
 
 version: 1
 
-hosts:
-  build-box:
-    ssh:
-      - build.local          # Try local network first
-      - build-tailscale      # Fall back to Tailscale
-    dir: ${HOME}/projects/${PROJECT}
-    env:
-      PYTHONDONTWRITEBYTECODE: "1"
-
-default: build-box
+# Reference the host from your global config
+# If omitted, all global hosts are available
+host: build-box
 
 sync:
   exclude:

--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -123,9 +123,12 @@ Edit `~/.ssh/config` (create it if it doesn't exist):
 Host devbox
     HostName 192.168.1.50
     User riley
+    IdentityFile ~/.ssh/id_ed25519
 ```
 
-Now `ssh devbox` connects to `riley@192.168.1.50`.
+Now `ssh devbox` connects to `riley@192.168.1.50` using your key.
+
+The `IdentityFile` line tells SSH which private key to use. This is what makes the connection passwordless (assuming you've copied the public key to the remote with `ssh-copy-id`).
 
 ### Multiple ways to reach the same machine
 
@@ -135,15 +138,18 @@ If your machine is reachable via LAN and Tailscale, set up both:
 Host devbox-lan
     HostName 192.168.1.50
     User riley
+    IdentityFile ~/.ssh/id_ed25519
 
 Host devbox-tailscale
     HostName devbox.tailnet-name.ts.net
     User riley
+    IdentityFile ~/.ssh/id_ed25519
 ```
 
-Then in your `.rr.yaml`, list both and rr will use whichever one is reachable:
+Then in your global config (`~/.rr/config.yaml`), list both and rr will use whichever one is reachable:
 
 ```yaml
+# ~/.rr/config.yaml
 hosts:
   devbox:
     ssh:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,10 +115,11 @@ DEPENDENCIES
 2. **Network issue** - Check your connection (VPN, firewall, etc.)
 3. **Wrong hostname/IP** - Verify the address in your config
 
-**Increase probe timeout** if hosts are slow to respond:
+**Increase probe timeout** if hosts are slow to respond (in `~/.rr/config.yaml`):
 
 ```yaml
-probe_timeout: 10s
+defaults:
+  probe_timeout: 10s
 ```
 
 Or per-command:
@@ -169,12 +170,14 @@ fi
        ProxyJump bastion
    ```
 
-2. **Use explicit `user@hostname` format** in `.rr.yaml` instead of SSH aliases:
+2. **Use explicit `user@hostname` format** in your global config instead of SSH aliases:
    ```yaml
+   # ~/.rr/config.yaml
    hosts:
      myserver:
        ssh:
          - deploy@192.168.1.100  # Explicit format, doesn't need SSH config
+       dir: ~/projects/${PROJECT}
    ```
 
 ### "command not found" on remote
@@ -185,8 +188,9 @@ fi
 
 **Fixes:**
 
-1. **Add shell config to `.rr.yaml`** (recommended):
+1. **Add shell config to your global config** (recommended):
    ```yaml
+   # ~/.rr/config.yaml
    hosts:
      myserver:
        ssh:
@@ -197,6 +201,7 @@ fi
 
 2. **Or use setup_commands** for specific initialization:
    ```yaml
+   # ~/.rr/config.yaml
    hosts:
      myserver:
        setup_commands:
@@ -333,9 +338,10 @@ rr init
 
 ### "No hosts configured"
 
-Add at least one host to your `.rr.yaml`:
+Add at least one host to your global config (`~/.rr/config.yaml`):
 
 ```yaml
+# ~/.rr/config.yaml
 hosts:
   myhost:
     ssh:
@@ -343,11 +349,26 @@ hosts:
     dir: ${HOME}/projects/${PROJECT}
 ```
 
+Or use the interactive command:
+
+```bash
+rr host add
+```
+
+### "Host 'X' not found in global config"
+
+The host referenced in your project's `.rr.yaml` doesn't exist in `~/.rr/config.yaml`. Either:
+
+1. Add the host to your global config with `rr host add`
+2. Remove the reference from `.rr.yaml`
+3. Check for typos in the host name
+
 ### "Host 'X' has no SSH aliases"
 
-Each host needs at least one SSH connection string:
+Each host needs at least one SSH connection string in the global config:
 
 ```yaml
+# ~/.rr/config.yaml
 hosts:
   myhost:
     ssh:
@@ -357,9 +378,10 @@ hosts:
 
 ### "Host 'X' has no dir"
 
-Each host needs a working directory:
+Each host needs a working directory in the global config:
 
 ```yaml
+# ~/.rr/config.yaml
 hosts:
   myhost:
     ssh:

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,44 @@
+# rr Claude Code skills
+
+This directory contains Claude Code skills that teach Claude how to use the `rr` CLI.
+
+For full documentation, see [docs/claude-code.md](../docs/claude-code.md).
+
+## Quick install
+
+```bash
+claude /plugin install rileyhilliard/rr
+```
+
+## Available skills
+
+### rr
+
+Teaches Claude to use the rr CLI for syncing code and running commands on remote machines.
+
+**Triggers automatically when:**
+- User wants to run tests, builds, or commands remotely
+- User needs to sync files to a remote host
+- User is setting up or troubleshooting rr configuration
+
+**Invoke manually:** `/rr`
+
+## Alternative installation
+
+### Personal skill
+
+```bash
+cp -r skills/rr ~/.claude/skills/
+```
+
+### Project-level
+
+The skill is automatically available when working in this repository.
+
+## What Claude learns
+
+- Two-config system (global `~/.rr/config.yaml` + project `.rr.yaml`)
+- All rr commands and their flags
+- Host management and load balancing
+- Common workflows and troubleshooting
+- Tasks and variable expansion

--- a/skills/rr/SKILL.md
+++ b/skills/rr/SKILL.md
@@ -1,0 +1,292 @@
+---
+name: rr
+description: Use the rr CLI to sync code and run commands on remote machines. Invoke when the user wants to run tests, builds, or commands remotely, sync files to a remote host, set up remote development, or troubleshoot rr configuration.
+user-invocable: true
+allowed-tools:
+  - Bash
+  - Read
+  - Edit
+  - Grep
+  - Glob
+---
+
+# rr (Road Runner) CLI
+
+rr syncs code to remote machines and runs commands there. It handles host failover, file sync with rsync, distributed locking, and test output formatting.
+
+## Quick Reference
+
+```bash
+rr run "make test"     # Sync files + run command
+rr exec "git status"   # Run command without syncing
+rr sync                # Just sync files
+rr doctor              # Diagnose issues
+rr monitor             # TUI dashboard for host metrics
+```
+
+## Two-Config System
+
+rr uses two config files with different purposes:
+
+### Global Config (`~/.rr/config.yaml`)
+
+Personal host definitions. Not shared with team. Contains SSH connections, directories, and machine-specific settings.
+
+```yaml
+version: 1
+
+hosts:
+  mini:
+    ssh:
+      - mac-mini.local      # LAN hostname - try first
+      - mac-mini-tailscale  # SSH config alias - fallback
+    dir: ${HOME}/projects/${PROJECT}
+    tags:
+      - fast
+    env:
+      DEBUG: "1"
+
+  server:
+    ssh:
+      - dev-server          # SSH config alias from ~/.ssh/config
+    dir: /var/projects/${PROJECT}
+
+defaults:
+  host: mini
+  local_fallback: false
+  probe_timeout: 2s
+```
+
+**SSH entries can be:**
+- Hostnames: `mac-mini.local`, `192.168.1.50`
+- User@host: `deploy@server.example.com`
+- SSH config aliases: Names defined in `~/.ssh/config` (e.g., `dev-server`, `mac-mini-tailscale`)
+
+**Passwordless SSH is required.** The user must be able to run `ssh <alias>` without entering a password. This typically means configuring key-based auth in `~/.ssh/config`.
+
+### Project Config (`.rr.yaml`)
+
+Shareable project settings. Can be committed to version control. References hosts by name from global config.
+
+```yaml
+version: 1
+
+# Reference hosts from global config (optional)
+hosts:
+  - mini
+  - server
+
+sync:
+  exclude:
+    - .git/
+    - node_modules/
+    - .venv/
+  preserve:
+    - .venv/
+    - node_modules/
+
+lock:
+  enabled: true
+  timeout: 5m
+
+tasks:
+  test:
+    run: pytest -v
+  build:
+    run: make build
+```
+
+## Commands
+
+### Core Commands
+
+| Command | Purpose |
+|---------|---------|
+| `rr run "cmd"` | Sync files, then run command |
+| `rr exec "cmd"` | Run command without syncing |
+| `rr sync` | Just sync files, no command |
+| `rr <taskname>` | Run named task from config |
+
+### Host Management
+
+| Command | Purpose |
+|---------|---------|
+| `rr host list` | List configured hosts |
+| `rr host add` | Add new host interactively |
+| `rr host remove <name>` | Remove a host |
+
+### Diagnostics & Monitoring
+
+| Command | Purpose |
+|---------|---------|
+| `rr doctor` | Diagnose SSH, config, dependency issues |
+| `rr monitor` | TUI dashboard showing CPU/RAM/GPU |
+| `rr status` | Show connection and sync status |
+
+### Setup & Utilities
+
+| Command | Purpose |
+|---------|---------|
+| `rr init` | Create .rr.yaml in current project |
+| `rr setup <host>` | Configure SSH keys for a host |
+| `rr unlock` | Release stuck lock on default host |
+| `rr unlock --all` | Release locks on all hosts |
+| `rr update` | Update rr to latest version |
+| `rr completion <shell>` | Generate shell completions |
+
+## Common Flags
+
+Most commands accept:
+
+- `--host <name>` - Target specific host
+- `--tag <tag>` - Select host by tag
+- `--probe-timeout <duration>` - SSH probe timeout (e.g., `5s`)
+
+Sync-specific:
+- `--dry-run` - Show what would sync without syncing
+
+## Variable Expansion
+
+The `dir` field in host config supports:
+
+| Variable | Expands to |
+|----------|------------|
+| `${PROJECT}` | Current directory name |
+| `${USER}` | Local username |
+| `${HOME}` | Remote user's home directory |
+
+## Tasks
+
+Define reusable commands in `.rr.yaml`:
+
+```yaml
+tasks:
+  test:
+    description: Run all tests
+    run: pytest -v
+
+  deploy:
+    description: Build and deploy
+    steps:
+      - name: Build
+        run: make build
+      - name: Deploy
+        run: ./deploy.sh
+        on_fail: stop
+```
+
+Run with: `rr test`, `rr deploy`
+
+## How It Works
+
+1. **Host Selection**: Tries SSH aliases in order until one connects and is not busy
+2. **File Sync**: Uses rsync with exclude/preserve patterns
+3. **Locking**: Creates lock on remote before running; if host locked, tries next host
+4. **Load Balancing**: When all hosts locked, round-robins until one frees up
+5. **Output Formatting**: Auto-detects pytest/jest/go test and formats failures
+
+## Troubleshooting
+
+### Check Configuration
+
+```bash
+rr doctor           # Full diagnostic
+rr host list        # See configured hosts
+```
+
+### Connection Issues
+
+If SSH fails:
+1. Verify `ssh <alias>` works manually
+2. Check `~/.rr/config.yaml` has correct SSH aliases
+3. Run `rr doctor` for detailed diagnostics
+
+### Sync Slow
+
+Add exclusions to `.rr.yaml`:
+
+```yaml
+sync:
+  exclude:
+    - .git/
+    - node_modules/
+    - .venv/
+    - __pycache__/
+```
+
+### Stuck Lock
+
+```bash
+rr unlock              # Default host
+rr unlock <hostname>   # Specific host
+rr unlock --all        # All hosts
+```
+
+## When to Use Each Command
+
+| Situation | Command |
+|-----------|---------|
+| Run tests with latest code | `rr run "make test"` |
+| Quick check on remote | `rr exec "git log -1"` |
+| Prep remote before multiple runs | `rr sync` |
+| Debug connection issues | `rr doctor` |
+| Watch resource usage | `rr monitor` |
+| First time setup in project | `rr init` |
+| Add new remote machine | `rr host add` |
+
+## Example Workflows
+
+### Initial Setup
+
+```bash
+# 1. Add a host to global config
+rr host add
+
+# 2. Initialize project config
+cd your-project
+rr init
+
+# 3. Verify everything works
+rr doctor
+
+# 4. Run something
+rr run "make test"
+```
+
+### Daily Development
+
+```bash
+# Run tests
+rr run "pytest -v"
+
+# Or use a named task
+rr test
+
+# Quick command without sync
+rr exec "git status"
+
+# Monitor hosts while working
+rr monitor
+```
+
+### Multiple Hosts (Load Balancing)
+
+```yaml
+# ~/.rr/config.yaml
+hosts:
+  gpu-1:
+    ssh: [gpu1.local, gpu1-tailscale]
+    dir: ~/projects/${PROJECT}
+  gpu-2:
+    ssh: [gpu2.local, gpu2-tailscale]
+    dir: ~/projects/${PROJECT}
+```
+
+```yaml
+# .rr.yaml
+hosts:
+  - gpu-1
+  - gpu-2
+```
+
+Now `rr run` automatically uses whichever GPU box is free.


### PR DESCRIPTION
## Summary

- Update all documentation to reflect the infrastructure change where host config moved from per-repo (`.rr.yaml`) to global (`~/.rr/config.yaml`)
- Add Claude Code plugin with `rr` skill for AI-assisted usage
- Improve SSH setup guide with explicit `IdentityFile` examples for passwordless auth

## Changes

**Documentation updates:**
- Docs now explain two-config system (global hosts + project settings)
- Example configs split into global and project examples
- SSH setup guide shows `IdentityFile` to clarify passwordless auth setup
- CLAUDE.md updated with new config structure

**New Claude Code plugin:**
- `.claude-plugin/plugin.json` - Plugin manifest
- `skills/rr/SKILL.md` - Skill teaching Claude how to use rr
- `docs/claude-code.md` - Plugin installation docs

## Test plan

- [ ] Verify docs accurately describe current behavior
- [ ] Test plugin installation with `claude /plugin install rileyhilliard/rr`