### PR TITLE
feat: add task argument passthrough and rr tasks command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ tasks:
 Then run them by name:
 
 ```bash
-rr test    # Same as: rr run "pytest -n auto"
+rr test                    # Same as: rr run "pytest -n auto"
 rr build
+rr test tests/test_api.py  # Pass extra args: pytest -n auto tests/test_api.py
+rr tasks                   # List all available tasks
 ```
 
 ![demo-tasks](https://github.com/user-attachments/assets/8d902e99-9b7a-4fa9-a2fa-bbdef8365e3b)
@@ -177,6 +179,7 @@ See [docs/configuration.md](docs/configuration.md) for all options.
 ## Other commands
 
 ```bash
+rr tasks                # List available tasks
 rr monitor              # TUI dashboard showing CPU/RAM/GPU across hosts
 rr status               # Show connection and sync status
 rr host list            # List configured hosts

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -369,6 +369,22 @@ Examples:
 	},
 }
 
+// tasksCmd lists available tasks
+var tasksCmd = &cobra.Command{
+	Use:   "tasks",
+	Short: "List available tasks",
+	Long: `List all tasks defined in your .rr.yaml configuration.
+
+Shows task names, descriptions, commands, and any host restrictions.
+Tasks can be run directly as top-level commands (e.g., 'rr test').
+
+Examples:
+  rr tasks`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return ListTasks()
+	},
+}
+
 func init() {
 	// run command flags
 	runCmd.Flags().StringVar(&runHostFlag, "host", "", "target host name")
@@ -421,4 +437,5 @@ func init() {
 	rootCmd.AddCommand(completionCmd)
 	rootCmd.AddCommand(hostCmd)
 	rootCmd.AddCommand(unlockCmd)
+	rootCmd.AddCommand(tasksCmd)
 }

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -234,7 +234,7 @@ func TestRegisterTaskCommandsAddsToRoot(t *testing.T) {
 	// Find the added command
 	var foundTask *cobra.Command
 	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "mytask" {
+		if strings.HasPrefix(cmd.Use, "mytask") {
 			foundTask = cmd
 			break
 		}

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -82,7 +82,7 @@ func TestCreateTaskCommand_BasicCommand(t *testing.T) {
 
 	cmd := createTaskCommand("test", task)
 
-	assert.Equal(t, "test", cmd.Use)
+	assert.Equal(t, "test [args...]", cmd.Use)
 	assert.Equal(t, "Run tests", cmd.Short)
 	assert.NotNil(t, cmd.RunE)
 }
@@ -94,7 +94,7 @@ func TestCreateTaskCommand_EmptyDescription(t *testing.T) {
 
 	cmd := createTaskCommand("build", task)
 
-	assert.Equal(t, "build", cmd.Use)
+	assert.Equal(t, "build [args...]", cmd.Use)
 	assert.Equal(t, "Run the 'build' task", cmd.Short)
 }
 

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -23,6 +23,8 @@ var ReservedTaskNames = map[string]bool{
 	"completion": true,
 	"update":     true,
 	"host":       true,
+	"unlock":     true,
+	"tasks":      true,
 }
 
 // ValidationOption controls validation behavior.

--- a/skills/rr/SKILL.md
+++ b/skills/rr/SKILL.md
@@ -106,6 +106,7 @@ tasks:
 | `rr exec "cmd"` | Run command without syncing |
 | `rr sync` | Just sync files, no command |
 | `rr <taskname>` | Run named task from config |
+| `rr tasks` | List all available tasks |
 
 ### Host Management
 
@@ -176,6 +177,15 @@ tasks:
 ```
 
 Run with: `rr test`, `rr deploy`
+
+Extra arguments are appended to single-command tasks:
+
+```bash
+rr test tests/test_api.py    # Runs: pytest -v tests/test_api.py
+rr test -k "test_login"      # Runs: pytest -v -k "test_login"
+```
+
+Note: Args are only supported for tasks with a single `run` command, not multi-step tasks.
 
 ## How It Works
 


### PR DESCRIPTION
## Summary

- Add `rr tasks` command to list all available tasks with descriptions
- Tasks now accept extra arguments that get appended to the command
- Add "tasks" and "unlock" to reserved task names

## Task Arguments

Extra arguments passed to a task are appended to the command:

```bash
# If you have a task:
# tasks:
#   test:
#     run: pytest -v

rr test                     # Runs: pytest -v
rr test tests/test_api.py   # Runs: pytest -v tests/test_api.py
rr test -k "test_login"     # Runs: pytest -v -k "test_login"
```

Note: Args are only supported for single-command tasks, not multi-step tasks.

## rr tasks

New command to list available tasks:

```bash
$ rr tasks
Available tasks (2):

  build  Build the project
    make build

  test  Run all tests
    pytest -v

Run a task:
  rr test
```

## Test plan
- [x] All existing tests pass
- [x] New test for arg passthrough (`TestExecuteTask_SingleCommandWithArgs`)
- [x] Task command tests updated for new `[args...]` usage format

🤖 Generated with [Claude Code](https://claude.com/claude-code)