### PR TITLE
feat: add project-level defaults and multi-step task progress

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.24.11
+go 1.24.2
 
 require (
 	github.com/charmbracelet/bubbles v0.21.1-0.20250623103423-23b8fd6302d7

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -65,7 +65,12 @@ func Run(opts RunOptions) (int, error) {
 		exitCode, err = exec.ExecuteLocal(opts.Command, wf.WorkDir, streamHandler.Stdout(), streamHandler.Stderr())
 	} else {
 		// Remote execution - build command with shell config, setup commands, and working directory
-		fullCmd := exec.BuildRemoteCommand(opts.Command, &wf.Conn.Host)
+		// Prepend project defaults setup to the command for consistency with task execution
+		cmd := opts.Command
+		if len(wf.Resolved.Project.Defaults.Setup) > 0 {
+			cmd = strings.Join(wf.Resolved.Project.Defaults.Setup, " && ") + " && " + cmd
+		}
+		fullCmd := exec.BuildRemoteCommand(cmd, &wf.Conn.Host)
 		exitCode, err = wf.Conn.Client.ExecStream(fullCmd, streamHandler.Stdout(), streamHandler.Stderr())
 	}
 	execDuration := time.Since(execStart)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -29,17 +29,31 @@ type GlobalDefaults struct {
 	LocalFallback bool `yaml:"local_fallback" mapstructure:"local_fallback"`
 }
 
+// ProjectDefaults contains default settings applied to all tasks in a project.
+// These are merged with host-level and task-level settings.
+type ProjectDefaults struct {
+	// Setup commands run before each task command.
+	// These are prepended after host setup_commands but before the task command.
+	// Useful for sourcing environments, setting shell options, etc.
+	Setup []string `yaml:"setup" mapstructure:"setup"`
+
+	// Env contains environment variables applied to all tasks.
+	// These override host env but are overridden by task-specific env.
+	Env map[string]string `yaml:"env" mapstructure:"env"`
+}
+
 // Config represents the project-level .rr.yaml configuration file.
 // This is shareable with the team and doesn't contain host connection details.
 type Config struct {
-	Version int                   `yaml:"version" mapstructure:"version"`
-	Host    string                `yaml:"host,omitempty" mapstructure:"host"`   // Single host reference (backwards compat)
-	Hosts   []string              `yaml:"hosts,omitempty" mapstructure:"hosts"` // Multiple host references for load balancing
-	Sync    SyncConfig            `yaml:"sync" mapstructure:"sync"`
-	Lock    LockConfig            `yaml:"lock" mapstructure:"lock"`
-	Tasks   map[string]TaskConfig `yaml:"tasks" mapstructure:"tasks"`
-	Output  OutputConfig          `yaml:"output" mapstructure:"output"`
-	Monitor MonitorConfig         `yaml:"monitor" mapstructure:"monitor"`
+	Version  int                   `yaml:"version" mapstructure:"version"`
+	Host     string                `yaml:"host,omitempty" mapstructure:"host"`   // Single host reference (backwards compat)
+	Hosts    []string              `yaml:"hosts,omitempty" mapstructure:"hosts"` // Multiple host references for load balancing
+	Defaults ProjectDefaults       `yaml:"defaults" mapstructure:"defaults"`
+	Sync     SyncConfig            `yaml:"sync" mapstructure:"sync"`
+	Lock     LockConfig            `yaml:"lock" mapstructure:"lock"`
+	Tasks    map[string]TaskConfig `yaml:"tasks" mapstructure:"tasks"`
+	Output   OutputConfig          `yaml:"output" mapstructure:"output"`
+	Monitor  MonitorConfig         `yaml:"monitor" mapstructure:"monitor"`
 }
 
 // Host defines a remote machine and its connection settings.


### PR DESCRIPTION
## Summary

- Add project-level `defaults` section to reduce task config verbosity
- Add multi-step task progress output for better visibility
- Fix `rr run` to apply project defaults.setup consistently

## Features

### 1. Project-level defaults

Reduce repetition across tasks with a new `defaults` section:

```yaml
# .rr.yaml
defaults:
  setup:
    - source ~/.local/bin/env
    - set -o pipefail
  env:
    PYTHONDONTWRITEBYTECODE: "1"

tasks:
  test:
    run: uv run pytest  # defaults.setup runs first automatically
```

### 2. Multi-step task progress

Multi-step tasks now show clear progress:

```
━━━ Step 1/3: Build ━━━
$ make build
[output...]
● Step 1/3: Build (2.3s)

━━━ Step 2/3: Test ━━━
$ pytest -v
[output...]
● Step 2/3: Test (45.1s)
```

## Test plan

- [x] Tested on m4-mini (macOS) - single task and multi-step task
- [x] Tested on m1-linux (Fedora) - single task and multi-step task
- [x] Verified `defaults.setup` applies to both `rr run` and `rr <task>`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)