### PR TITLE
fix: respect local_fallback in project config and add --local flag

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -14,9 +14,11 @@ var (
 	runHostFlag          string
 	runTagFlag           string
 	runProbeTimeoutFlag  string
+	runLocalFlag         bool
 	execHostFlag         string
 	execTagFlag          string
 	execProbeTimeoutFlag string
+	execLocalFlag        bool
 	syncHostFlag         string
 	syncTagFlag          string
 	syncProbeTimeoutFlag string
@@ -48,7 +50,7 @@ Examples:
   rr run --host mini "cargo test"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runCommand(args, runHostFlag, runTagFlag, runProbeTimeoutFlag)
+		return runCommand(args, runHostFlag, runTagFlag, runProbeTimeoutFlag, runLocalFlag)
 	},
 }
 
@@ -66,7 +68,7 @@ Examples:
   rr exec "cat /var/log/app.log"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return execCommand(args, execHostFlag, execTagFlag, execProbeTimeoutFlag)
+		return execCommand(args, execHostFlag, execTagFlag, execProbeTimeoutFlag, execLocalFlag)
 	},
 }
 
@@ -390,11 +392,13 @@ func init() {
 	runCmd.Flags().StringVar(&runHostFlag, "host", "", "target host name")
 	runCmd.Flags().StringVar(&runTagFlag, "tag", "", "select host by tag")
 	runCmd.Flags().StringVar(&runProbeTimeoutFlag, "probe-timeout", "", "SSH probe timeout (e.g., 5s, 2m)")
+	runCmd.Flags().BoolVar(&runLocalFlag, "local", false, "force local execution (skip remote hosts)")
 
 	// exec command flags
 	execCmd.Flags().StringVar(&execHostFlag, "host", "", "target host name")
 	execCmd.Flags().StringVar(&execTagFlag, "tag", "", "select host by tag")
 	execCmd.Flags().StringVar(&execProbeTimeoutFlag, "probe-timeout", "", "SSH probe timeout (e.g., 5s, 2m)")
+	execCmd.Flags().BoolVar(&execLocalFlag, "local", false, "force local execution (skip remote hosts)")
 
 	// sync command flags
 	syncCmd.Flags().StringVar(&syncHostFlag, "host", "", "target host name")

--- a/internal/cli/exec_cmd.go
+++ b/internal/cli/exec_cmd.go
@@ -8,7 +8,7 @@ import (
 
 // execCommand executes a command without syncing files first.
 // This shares the core logic with run but skips the sync phase.
-func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string) error {
+func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag bool) error {
 	if len(args) == 0 {
 		return errors.New(errors.ErrExec,
 			"What should I run?",
@@ -30,6 +30,7 @@ func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string) erro
 		ProbeTimeout: probeTimeout,
 		SkipSync:     true, // Key difference from run
 		Quiet:        Quiet(),
+		Local:        localFlag,
 	})
 
 	if err != nil {

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -14,13 +14,15 @@ type CommonFlags struct {
 	Host         string
 	Tag          string
 	ProbeTimeout string
+	Local        bool
 }
 
-// AddCommonFlags registers --host, --tag, and --probe-timeout flags on a command.
+// AddCommonFlags registers --host, --tag, --probe-timeout, and --local flags on a command.
 func AddCommonFlags(cmd *cobra.Command, flags *CommonFlags) {
 	cmd.Flags().StringVar(&flags.Host, "host", "", "target host name")
 	cmd.Flags().StringVar(&flags.Tag, "tag", "", "select host by tag")
 	cmd.Flags().StringVar(&flags.ProbeTimeout, "probe-timeout", "", "SSH probe timeout (e.g., 5s, 2m)")
+	cmd.Flags().BoolVar(&flags.Local, "local", false, "force local execution (skip remote hosts)")
 }
 
 // ParseProbeTimeout parses a probe timeout string into a duration.

--- a/internal/cli/host.go
+++ b/internal/cli/host.go
@@ -64,7 +64,7 @@ func hostAdd(opts HostAddOptions) error {
 			}
 		}
 		if remoteDir == "" {
-			remoteDir = "${HOME}/rr/${PROJECT}"
+			remoteDir = "~/rr/${PROJECT}"
 		}
 
 		// Prompt to confirm or change

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -218,7 +218,7 @@ func collectMachineConfig(excludeSSHHosts []string, skipProbe bool) (*machineCon
 	}
 
 	// Prompt for remote directory
-	machine.remoteDir = "${HOME}/rr/${PROJECT}"
+	machine.remoteDir = "~/rr/${PROJECT}"
 	if err := promptRemoteDir(&machine.remoteDir); err != nil {
 		return nil, false, err
 	}
@@ -325,7 +325,7 @@ func promptRemoteDir(remoteDir *string) error {
 			huh.NewInput().
 				Title("Remote directory").
 				Description("Where files sync to (supports ${PROJECT}, ${USER}, ${HOME}, ~)").
-				Placeholder("${HOME}/rr/${PROJECT}").
+				Placeholder("~/rr/${PROJECT}").
 				Value(remoteDir).
 				Validate(func(s string) error {
 					if strings.TrimSpace(s) == "" {
@@ -532,6 +532,11 @@ func generateProjectConfigContent(vals *projectConfigValues) string {
 		sb.WriteString("#   - my-host\n")
 		sb.WriteString("#   - other-host\n\n")
 	}
+
+	// Local fallback
+	sb.WriteString("# Run locally when all remote hosts fail or are unreachable\n")
+	sb.WriteString("# Set to true to fall back to local execution instead of failing\n")
+	sb.WriteString("# local_fallback: false\n\n")
 
 	// Sync section
 	sb.WriteString("# File sync settings (uses rsync under the hood)\n")
@@ -884,7 +889,7 @@ func collectNonInteractiveValues(opts InitOptions, globalCfg *config.GlobalConfi
 				remoteDir: opts.Dir,
 			}
 			if machine.remoteDir == "" {
-				machine.remoteDir = "${HOME}/rr/${PROJECT}"
+				machine.remoteDir = "~/rr/${PROJECT}"
 			}
 
 			// Test connection if not skipping probe

--- a/internal/cli/init_test.go
+++ b/internal/cli/init_test.go
@@ -366,7 +366,7 @@ func TestInit_NonInteractive_DefaultRemoteDir(t *testing.T) {
 	// Default remote dir should be in global config
 	globalContent, err := os.ReadFile(filepath.Join(tmpDir, ".rr", "config.yaml"))
 	require.NoError(t, err)
-	assert.Contains(t, string(globalContent), "${HOME}/rr/${PROJECT}")
+	assert.Contains(t, string(globalContent), "~/rr/${PROJECT}")
 }
 
 func TestInitOptions_Defaults(t *testing.T) {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -26,6 +26,7 @@ type RunOptions struct {
 	DryRun       bool          // If true, show what would be done without doing it
 	WorkingDir   string        // Override local working directory
 	Quiet        bool          // If true, minimize output (no individual connection attempts)
+	Local        bool          // If true, force local execution (skip remote hosts)
 }
 
 // Run syncs files and executes a command on the remote host.
@@ -40,6 +41,7 @@ func Run(opts RunOptions) (int, error) {
 		SkipLock:     opts.SkipLock,
 		WorkingDir:   opts.WorkingDir,
 		Quiet:        opts.Quiet,
+		Local:        opts.Local,
 	})
 	if err != nil {
 		return 1, err
@@ -266,7 +268,7 @@ func mapProbeErrorToStatus(err error) ui.ConnectionStatus {
 }
 
 // runCommand is the actual implementation called by the cobra command.
-func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string) error {
+func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag bool) error {
 	if len(args) == 0 {
 		return errors.New(errors.ErrExec,
 			"What should I run?",
@@ -287,6 +289,7 @@ func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string) error
 		Tag:          tagFlag,
 		ProbeTimeout: probeTimeout,
 		Quiet:        Quiet(),
+		Local:        localFlag,
 	})
 
 	if err != nil {

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -125,13 +125,13 @@ func TestRunOptions_WithValues(t *testing.T) {
 }
 
 func TestRunCommand_NoArgs(t *testing.T) {
-	err := runCommand([]string{}, "", "", "")
+	err := runCommand([]string{}, "", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
 
 func TestRunCommand_InvalidProbeTimeout(t *testing.T) {
-	err := runCommand([]string{"echo hello"}, "", "", "invalid-timeout")
+	err := runCommand([]string{"echo hello"}, "", "", "invalid-timeout", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "doesn't look like a valid timeout")
 }
@@ -150,7 +150,7 @@ func TestRunCommand_JoinsArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined into single command
-	err = runCommand([]string{"make", "test"}, "", "", "")
+	err = runCommand([]string{"make", "test"}, "", "", "", false)
 	require.Error(t, err)
 	// Should fail on no hosts configured
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -168,20 +168,20 @@ func TestRunCommand_ValidProbeTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Valid probe timeout should not fail on parsing
-	err = runCommand([]string{"echo"}, "", "", "5s")
+	err = runCommand([]string{"echo"}, "", "", "5s", false)
 	require.Error(t, err)
 	// Should fail on no hosts configured, not on probe timeout
 	assert.NotContains(t, err.Error(), "timeout")
 }
 
 func TestExecCommand_NoArgs(t *testing.T) {
-	err := execCommand([]string{}, "", "", "")
+	err := execCommand([]string{}, "", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
 
 func TestExecCommand_InvalidProbeTimeout(t *testing.T) {
-	err := execCommand([]string{"ls"}, "", "", "bad-duration")
+	err := execCommand([]string{"ls"}, "", "", "bad-duration", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "doesn't look like a valid timeout")
 }
@@ -198,7 +198,7 @@ func TestExecCommand_JoinsArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined
-	err = execCommand([]string{"ls", "-la"}, "", "", "")
+	err = execCommand([]string{"ls", "-la"}, "", "", "", false)
 	require.Error(t, err)
 	// Should fail on no hosts configured
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -227,7 +227,7 @@ func TestExecCommand_ValidProbeTimeoutFormats(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := execCommand([]string{"ls"}, "", "", tt.timeout)
+			err := execCommand([]string{"ls"}, "", "", tt.timeout, false)
 			// Should fail with config error, not parse error
 			if err != nil {
 				assert.NotContains(t, err.Error(), "doesn't look like a valid timeout",
@@ -470,7 +470,7 @@ func TestRunOptions_ZeroValues(t *testing.T) {
 }
 
 func TestRunCommand_EmptyArgs(t *testing.T) {
-	err := runCommand([]string{}, "", "", "")
+	err := runCommand([]string{}, "", "", "", false)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
@@ -487,7 +487,7 @@ func TestRunCommand_MultipleArgsJoined(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined with spaces
-	err = runCommand([]string{"make", "test", "-v"}, "", "", "")
+	err = runCommand([]string{"make", "test", "-v"}, "", "", "", false)
 	require.Error(t, err)
 	// Fails on no hosts configured, but args were processed
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -504,7 +504,7 @@ func TestRunCommand_WithHostAndTag(t *testing.T) {
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	err = runCommand([]string{"echo"}, "myhost", "mytag", "")
+	err = runCommand([]string{"echo"}, "myhost", "mytag", "", false)
 	require.Error(t, err)
 	// Should fail on no hosts configured, flags were accepted
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -521,7 +521,7 @@ func TestExecCommand_MultipleArgsJoined(t *testing.T) {
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	err = execCommand([]string{"ls", "-la", "/tmp"}, "", "", "")
+	err = execCommand([]string{"ls", "-la", "/tmp"}, "", "", "", false)
 	require.Error(t, err)
 	// Fails on no hosts configured, but args were processed
 	assert.Contains(t, err.Error(), "No hosts configured")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -45,15 +45,16 @@ type ProjectDefaults struct {
 // Config represents the project-level .rr.yaml configuration file.
 // This is shareable with the team and doesn't contain host connection details.
 type Config struct {
-	Version  int                   `yaml:"version" mapstructure:"version"`
-	Host     string                `yaml:"host,omitempty" mapstructure:"host"`   // Single host reference (backwards compat)
-	Hosts    []string              `yaml:"hosts,omitempty" mapstructure:"hosts"` // Multiple host references for load balancing
-	Defaults ProjectDefaults       `yaml:"defaults" mapstructure:"defaults"`
-	Sync     SyncConfig            `yaml:"sync" mapstructure:"sync"`
-	Lock     LockConfig            `yaml:"lock" mapstructure:"lock"`
-	Tasks    map[string]TaskConfig `yaml:"tasks" mapstructure:"tasks"`
-	Output   OutputConfig          `yaml:"output" mapstructure:"output"`
-	Monitor  MonitorConfig         `yaml:"monitor" mapstructure:"monitor"`
+	Version       int                   `yaml:"version" mapstructure:"version"`
+	Host          string                `yaml:"host,omitempty" mapstructure:"host"`   // Single host reference (backwards compat)
+	Hosts         []string              `yaml:"hosts,omitempty" mapstructure:"hosts"` // Multiple host references for load balancing
+	LocalFallback *bool                 `yaml:"local_fallback,omitempty" mapstructure:"local_fallback"`
+	Defaults      ProjectDefaults       `yaml:"defaults" mapstructure:"defaults"`
+	Sync          SyncConfig            `yaml:"sync" mapstructure:"sync"`
+	Lock          LockConfig            `yaml:"lock" mapstructure:"lock"`
+	Tasks         map[string]TaskConfig `yaml:"tasks" mapstructure:"tasks"`
+	Output        OutputConfig          `yaml:"output" mapstructure:"output"`
+	Monitor       MonitorConfig         `yaml:"monitor" mapstructure:"monitor"`
 }
 
 // Host defines a remote machine and its connection settings.


### PR DESCRIPTION
## Summary
- Fixes #66 - hosts being used even when removed from project config, no local fallback
- Add support for `local_fallback` in project config (overrides global when set)
- Add `--local` flag to run/exec/task commands to force local execution
- Include `local_fallback` in generated `.rr.yaml` config with documentation comments
- #65 

## Changes
- `internal/config/types.go`: Add `LocalFallback *bool` to project Config
- `internal/config/loader.go`: Add `ResolveLocalFallback()` helper, fix `ResolveHosts()` to not fall back to global hosts when local_fallback enabled
- `internal/host/selector.go`: Handle empty hosts with local_fallback by immediately returning local connection
- `internal/cli/workflow.go`: Use resolved local_fallback, add `Local` option
- `internal/cli/flags.go`, `commands.go`, `run.go`, `exec_cmd.go`, `task.go`: Add `--local` flag
- `internal/cli/init.go`: Include `local_fallback` in generated config template

Also includes:
- Better rsync version detection with helpful upgrade suggestions
- Cleaner default remote dir (`~/` instead of `${HOME}/`)

## Test plan
- [x] Build passes
- [x] Lint passes  
- [x] Manual test: `local_fallback: true` in project config works
- [x] Manual test: `--local` flag forces local execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)