### PR TITLE
fix: correct semver comparison for version updates

### DIFF
--- a/internal/cli/update_test.go
+++ b/internal/cli/update_test.go
@@ -100,6 +100,36 @@ func TestIsNewerVersion(t *testing.T) {
 			latest:  "1.0.0",
 			want:    false,
 		},
+		{
+			name:    "minor version 9 to 10",
+			current: "0.9.1",
+			latest:  "0.10.0",
+			want:    true,
+		},
+		{
+			name:    "minor version 10 is not older than 9",
+			current: "0.10.0",
+			latest:  "0.9.1",
+			want:    false,
+		},
+		{
+			name:    "major version 9 to 10",
+			current: "9.0.0",
+			latest:  "10.0.0",
+			want:    true,
+		},
+		{
+			name:    "patch version 9 to 10",
+			current: "1.0.9",
+			latest:  "1.0.10",
+			want:    true,
+		},
+		{
+			name:    "complex version comparison",
+			current: "0.9.99",
+			latest:  "0.10.0",
+			want:    true,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Fix version comparison in the update command that was incorrectly using string comparison instead of numeric semver comparison.

## Problem
The update command determined that v0.10.0 < v0.9.1 because string comparison compares character by character ("1" < "9").

## Solution
Parse semver components (major, minor, patch) as integers and compare numerically.

## Test Plan
- [x] Added test cases for 0.9.x to 0.10.x version comparisons
- [x] All existing tests pass