### PR TITLE
fix: speed up SSH server readiness check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,51 +128,25 @@ jobs:
             -e PUBLIC_KEY="$(cat /tmp/rr-ci-ssh-keys/id_ed25519.pub)" \
             linuxserver/openssh-server
 
-          # Wait for SSH daemon to be fully ready (not just port open)
-          echo "Waiting for SSH server to initialize..."
-          for i in {1..60}; do
-            # Check if sshd process is running inside container
-            if docker exec rr-ci-ssh pgrep -x sshd >/dev/null 2>&1; then
-              # Also verify TCP port is accepting connections
-              if nc -z localhost 2222 2>/dev/null; then
-                echo "SSH server is ready (attempt $i)"
-                break
-              fi
-            fi
-            echo "Waiting... (attempt $i)"
-            sleep 2
-          done
-
-          # Additional settle time for key configuration
-          sleep 3
-
-          # Add to known_hosts
+          # Wait for SSH to be ready by testing actual connection
+          echo "Waiting for SSH server to be ready..."
           mkdir -p ~/.ssh
-          for i in {1..5}; do
-            if ssh-keyscan -p 2222 localhost >> ~/.ssh/known_hosts 2>/dev/null; then
-              echo "Added host key to known_hosts"
-              break
-            fi
-            sleep 2
-          done
-
-          # Verify connection with retries
-          echo "Verifying SSH connection..."
-          for i in {1..5}; do
+          for i in {1..30}; do
             if ssh -i /tmp/rr-ci-ssh-keys/id_ed25519 \
                 -p 2222 \
-                -o StrictHostKeyChecking=no \
-                -o ConnectTimeout=10 \
-                testuser@localhost "echo 'SSH connection successful'"; then
-              echo "Connection verified!"
+                -o StrictHostKeyChecking=accept-new \
+                -o ConnectTimeout=2 \
+                -o BatchMode=yes \
+                testuser@localhost "echo ok" >/dev/null 2>&1; then
+              echo "SSH server ready (attempt $i)"
               exit 0
             fi
-            echo "Connection attempt $i failed, retrying..."
-            sleep 3
+            echo "Waiting... (attempt $i)"
+            sleep 1
           done
 
           # If we get here, show logs for debugging
-          echo "SSH connection failed after retries. Container logs:"
+          echo "SSH connection failed after 30 attempts. Container logs:"
           docker logs rr-ci-ssh
           exit 1
 


### PR DESCRIPTION
## Summary
- Replace broken `pgrep -x sshd && nc -z` readiness check with direct SSH connection attempt
- The old check never succeeded due to how linuxserver/openssh-server runs sshd via s6-overlay
- Reduces wait time from ~2 minutes to typically 10-20 seconds

## Test plan
- [ ] Verify CI integration tests still pass
- [ ] Confirm SSH server startup step completes faster

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD SSH connectivity verification with enhanced retry logic and error reporting. Streamlined readiness checks for more reliable deployment testing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->