### PR TITLE
feat: animated progress display for parallel task execution

### DIFF
--- a/internal/parallel/orchestrator.go
+++ b/internal/parallel/orchestrator.go
@@ -85,6 +85,13 @@ func (o *Orchestrator) Run(ctx context.Context) (*Result, error) {
 	o.outputMgr = NewOutputManager(o.config.OutputMode, isTTY)
 	defer o.outputMgr.Close()
 
+	// Show all tasks as pending upfront
+	taskNames := make([]string, len(o.tasks))
+	for i, t := range o.tasks {
+		taskNames[i] = t.Name
+	}
+	o.outputMgr.InitTasks(taskNames)
+
 	startTime := time.Now()
 
 	// Create task queue (channel-based work stealing).
@@ -160,6 +167,7 @@ func (o *Orchestrator) hostWorker(
 		failed:       failed,
 		failedMu:     failedMu,
 	}
+	defer worker.Close()
 
 	for task := range taskQueue {
 		// Check for cancellation
@@ -249,6 +257,13 @@ func (o *Orchestrator) runLocal(ctx context.Context) (*Result, error) {
 	// Initialize output manager
 	o.outputMgr = NewOutputManager(o.config.OutputMode, isTTY)
 	defer o.outputMgr.Close()
+
+	// Show all tasks as pending upfront
+	taskNames := make([]string, len(o.tasks))
+	for i, t := range o.tasks {
+		taskNames[i] = t.Name
+	}
+	o.outputMgr.InitTasks(taskNames)
 
 	startTime := time.Now()
 

--- a/internal/parallel/orchestrator_test.go
+++ b/internal/parallel/orchestrator_test.go
@@ -296,6 +296,7 @@ func TestTaskStatus_String(t *testing.T) {
 		want   string
 	}{
 		{TaskPending, "pending"},
+		{TaskSyncing, "syncing"},
 		{TaskRunning, "running"},
 		{TaskPassed, "passed"},
 		{TaskFailed, "failed"},

--- a/internal/parallel/types.go
+++ b/internal/parallel/types.go
@@ -74,7 +74,8 @@ type TaskStatus int
 
 const (
 	TaskPending TaskStatus = iota
-	TaskRunning
+	TaskSyncing            // Assigned to host, connecting/syncing/waiting for lock
+	TaskRunning            // Actually executing the command
 	TaskPassed
 	TaskFailed
 )
@@ -84,6 +85,8 @@ func (s TaskStatus) String() string {
 	switch s {
 	case TaskPending:
 		return "pending"
+	case TaskSyncing:
+		return "syncing"
 	case TaskRunning:
 		return "running"
 	case TaskPassed:

--- a/internal/ui/parallel_progress.go
+++ b/internal/ui/parallel_progress.go
@@ -1,0 +1,294 @@
+package ui
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// ParallelProgress displays animated progress for multiple concurrent tasks.
+// Uses in-place terminal updates so running tasks animate and completed
+// tasks transition smoothly without printing new lines.
+type ParallelProgress struct {
+	mu sync.Mutex
+
+	tasks     []taskEntry // Ordered list of tasks
+	lineCount int         // Number of lines currently rendered
+	frame     int         // Current animation frame
+
+	running  bool
+	stopChan chan struct{}
+	doneChan chan struct{}
+	output   io.Writer
+	isTTY    bool
+
+	// Styles
+	successStyle lipgloss.Style
+	errorStyle   lipgloss.Style
+	mutedStyle   lipgloss.Style
+	hostStyle    lipgloss.Style
+}
+
+type taskEntry struct {
+	Name      string
+	Host      string
+	Status    TaskStatus
+	StartTime time.Time
+}
+
+// TaskStatus values for parallel progress (matches parallel.TaskStatus)
+type TaskStatus int
+
+const (
+	TaskStatusPending TaskStatus = iota
+	TaskStatusSyncing            // Assigned to host, connecting/syncing/waiting for lock
+	TaskStatusRunning            // Actually executing the command
+	TaskStatusPassed
+	TaskStatusFailed
+)
+
+// NewParallelProgress creates a new parallel progress display.
+func NewParallelProgress(isTTY bool) *ParallelProgress {
+	return &ParallelProgress{
+		tasks:    make([]taskEntry, 0),
+		output:   os.Stdout,
+		isTTY:    isTTY,
+		stopChan: make(chan struct{}),
+		doneChan: make(chan struct{}),
+
+		successStyle: lipgloss.NewStyle().Foreground(ColorSuccess),
+		errorStyle:   lipgloss.NewStyle().Foreground(ColorError),
+		mutedStyle:   lipgloss.NewStyle().Foreground(ColorMuted),
+		hostStyle:    lipgloss.NewStyle().Foreground(ColorSecondary),
+	}
+}
+
+// SetWriter sets the output writer (useful for testing).
+func (p *ParallelProgress) SetWriter(w io.Writer) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.output = w
+}
+
+// Start begins the animation loop.
+func (p *ParallelProgress) Start() {
+	p.mu.Lock()
+	if p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = true
+	p.stopChan = make(chan struct{})
+	p.doneChan = make(chan struct{})
+	p.mu.Unlock()
+
+	go p.animate()
+}
+
+// Stop halts the animation and renders final state.
+func (p *ParallelProgress) Stop() {
+	p.mu.Lock()
+	if !p.running {
+		p.mu.Unlock()
+		return
+	}
+	p.running = false
+	close(p.stopChan)
+	p.mu.Unlock()
+
+	<-p.doneChan
+}
+
+// InitTasks initializes all tasks as pending. Call this before starting workers
+// to show all tasks upfront in the UI.
+func (p *ParallelProgress) InitTasks(taskNames []string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, name := range taskNames {
+		p.tasks = append(p.tasks, taskEntry{
+			Name:   name,
+			Host:   "",
+			Status: TaskStatusPending,
+		})
+	}
+
+	// Render initial state
+	p.renderLocked()
+}
+
+// TaskSyncing adds a new task in syncing state (connecting/syncing/waiting for lock).
+func (p *ParallelProgress) TaskSyncing(name, host string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Check if task already exists (shouldn't happen, but be safe)
+	for i := range p.tasks {
+		if p.tasks[i].Name == name {
+			p.tasks[i].Status = TaskStatusSyncing
+			p.tasks[i].Host = host
+			p.tasks[i].StartTime = time.Now()
+			p.renderLocked()
+			return
+		}
+	}
+
+	p.tasks = append(p.tasks, taskEntry{
+		Name:      name,
+		Host:      host,
+		Status:    TaskStatusSyncing,
+		StartTime: time.Now(),
+	})
+
+	// Immediate render for responsiveness
+	p.renderLocked()
+}
+
+// TaskExecuting transitions a task from syncing to running (command execution started).
+func (p *ParallelProgress) TaskExecuting(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for i := range p.tasks {
+		if p.tasks[i].Name == name {
+			p.tasks[i].Status = TaskStatusRunning
+			p.renderLocked()
+			return
+		}
+	}
+}
+
+// TaskStarted adds a new task in syncing state.
+//
+// Deprecated: Use TaskSyncing followed by TaskExecuting for clearer state tracking.
+func (p *ParallelProgress) TaskStarted(name, host string) {
+	p.TaskSyncing(name, host)
+}
+
+// TaskCompleted updates a task's status to passed or failed.
+func (p *ParallelProgress) TaskCompleted(name string, success bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for i := range p.tasks {
+		if p.tasks[i].Name == name {
+			if success {
+				p.tasks[i].Status = TaskStatusPassed
+			} else {
+				p.tasks[i].Status = TaskStatusFailed
+			}
+			break
+		}
+	}
+
+	// Immediate render to show completion
+	p.renderLocked()
+}
+
+// HasRunningTasks returns true if any tasks are still running or syncing.
+func (p *ParallelProgress) HasRunningTasks() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	for _, t := range p.tasks {
+		if t.Status == TaskStatusRunning || t.Status == TaskStatusSyncing {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *ParallelProgress) animate() {
+	ticker := time.NewTicker(80 * time.Millisecond) // Smooth animation
+	defer ticker.Stop()
+	defer close(p.doneChan)
+
+	for {
+		select {
+		case <-p.stopChan:
+			// Final render with all tasks in their final state
+			p.mu.Lock()
+			p.renderLocked()
+			p.mu.Unlock()
+			return
+		case <-ticker.C:
+			p.mu.Lock()
+			p.frame = (p.frame + 1) % len(spinnerFrames)
+			p.renderLocked()
+			p.mu.Unlock()
+		}
+	}
+}
+
+// renderLocked renders all task lines in-place. Must be called with lock held.
+func (p *ParallelProgress) renderLocked() {
+	if !p.isTTY || len(p.tasks) == 0 {
+		return
+	}
+
+	var sb strings.Builder
+
+	// Move cursor up to overwrite previous lines
+	if p.lineCount > 0 {
+		sb.WriteString(fmt.Sprintf("\x1b[%dA", p.lineCount))
+	}
+
+	// Render each task line
+	for _, task := range p.tasks {
+		line := p.renderTaskLine(task)
+		// Clear line and write new content
+		sb.WriteString("\x1b[K") // Clear to end of line
+		sb.WriteString(line)
+		sb.WriteString("\n")
+	}
+
+	fmt.Fprint(p.output, sb.String())
+	p.lineCount = len(p.tasks)
+}
+
+// renderTaskLine renders a single task with appropriate symbol and style.
+func (p *ParallelProgress) renderTaskLine(task taskEntry) string {
+	var symbol string
+	var style lipgloss.Style
+
+	switch task.Status {
+	case TaskStatusPending:
+		symbol = SymbolPending
+		style = p.mutedStyle
+	case TaskStatusSyncing:
+		// Slow pulsing animation for syncing (waiting for lock/sync)
+		symbol = SymbolSyncing
+		// Slower color pulse to differentiate from running
+		colorIdx := (p.frame / 4) % len(GradientColors)
+		style = lipgloss.NewStyle().Foreground(GradientColors[colorIdx])
+	case TaskStatusRunning:
+		// Animated spinner with color cycling
+		symbol = spinnerFrames[p.frame]
+		colorIdx := (p.frame / 2) % len(GradientColors)
+		style = lipgloss.NewStyle().Foreground(GradientColors[colorIdx])
+	case TaskStatusPassed:
+		symbol = SymbolSuccess
+		style = p.successStyle
+	case TaskStatusFailed:
+		symbol = SymbolFail
+		style = p.errorStyle
+	}
+
+	// Only show host if assigned
+	if task.Host != "" {
+		hostStr := p.mutedStyle.Render(fmt.Sprintf("[%s]", task.Host))
+		return fmt.Sprintf("%s %s %s", style.Render(symbol), task.Name, hostStr)
+	}
+	return fmt.Sprintf("%s %s", style.Render(symbol), task.Name)
+}
+
+// Finalize ensures proper cursor positioning after progress display.
+// Call this after Stop() and before printing additional output.
+func (p *ParallelProgress) Finalize() {
+	// Nothing extra needed - cursor is already at correct position
+}

--- a/internal/ui/parallel_progress_test.go
+++ b/internal/ui/parallel_progress_test.go
@@ -1,0 +1,154 @@
+package ui
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParallelProgress_TaskStarted(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	p.TaskStarted("build", "m1-linux")
+
+	// Give animation a tick to render
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+	assert.Contains(t, output, "build")
+	assert.Contains(t, output, "[m1-linux]")
+}
+
+func TestParallelProgress_TaskCompleted(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	p.TaskStarted("test", "dev")
+	p.TaskCompleted("test", true)
+
+	// Give animation a tick to render
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+	assert.Contains(t, output, "test")
+	assert.Contains(t, output, SymbolSuccess) // Should show success symbol
+}
+
+func TestParallelProgress_TaskFailed(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	p.TaskStarted("lint", "server")
+	p.TaskCompleted("lint", false)
+
+	// Give animation a tick
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+	assert.Contains(t, output, "lint")
+	assert.Contains(t, output, SymbolFail) // Should show fail symbol
+}
+
+func TestParallelProgress_MultipleTasks(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	// Start multiple tasks
+	p.TaskStarted("test-backend", "m1-linux")
+	p.TaskStarted("test-frontend", "m1-mini")
+	p.TaskStarted("test-opendata", "m4-mini")
+
+	// Give animation a tick
+	time.Sleep(100 * time.Millisecond)
+
+	// Complete tasks in different order
+	p.TaskCompleted("test-frontend", true)
+	p.TaskCompleted("test-opendata", true)
+	p.TaskCompleted("test-backend", true)
+
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+
+	// All tasks should be in output
+	assert.Contains(t, output, "test-backend")
+	assert.Contains(t, output, "test-frontend")
+	assert.Contains(t, output, "test-opendata")
+
+	// All hosts should be in output
+	assert.Contains(t, output, "[m1-linux]")
+	assert.Contains(t, output, "[m1-mini]")
+	assert.Contains(t, output, "[m4-mini]")
+}
+
+func TestParallelProgress_HasRunningTasks(t *testing.T) {
+	p := NewParallelProgress(false) // non-TTY mode for simpler test
+
+	assert.False(t, p.HasRunningTasks())
+
+	p.TaskStarted("task1", "host1")
+	assert.True(t, p.HasRunningTasks())
+
+	p.TaskCompleted("task1", true)
+	assert.False(t, p.HasRunningTasks())
+}
+
+func TestParallelProgress_NonTTY(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(false) // Non-TTY mode
+	p.SetWriter(&buf)
+	p.Start()
+
+	p.TaskStarted("test", "dev")
+
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	// In non-TTY mode, should not render (no terminal control)
+	output := buf.String()
+	assert.Empty(t, output)
+}
+
+func TestParallelProgress_AnimationFrames(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	p.TaskStarted("build", "host")
+
+	// Let multiple animation frames render
+	time.Sleep(300 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+
+	// Animation should produce ANSI escape sequences for cursor movement
+	// This indicates in-place updates are happening (the animation feature)
+	assert.Contains(t, output, "\x1b[", "output should contain ANSI escape sequences from animation")
+
+	// Should also contain task info
+	assert.Contains(t, output, "build")
+	assert.Contains(t, output, "[host]")
+}

--- a/internal/ui/symbols.go
+++ b/internal/ui/symbols.go
@@ -5,6 +5,7 @@ const (
 	SymbolSuccess  = "◉" // Task completed successfully (filled target)
 	SymbolFail     = "✕" // Task failed (clean X)
 	SymbolPending  = "◇" // Task not yet started (empty diamond)
+	SymbolSyncing  = "◐" // Task syncing/waiting for lock (half-filled)
 	SymbolProgress = "◆" // Task in progress (filled diamond)
 	SymbolComplete = "●" // Task done (solid circle)
 	SymbolSkipped  = "⊖" // Task skipped (circled minus)


### PR DESCRIPTION
## Summary

- Add animated braille spinner for running parallel tasks
- Color cycling through gradient (pink -> purple -> cyan -> green)  
- In-place terminal updates - running tasks animate, completed tasks transition to final symbol without new lines
- Add syncing vs executing state distinction for clearer progress feedback
- Document parallel execution feature prominently in README and configuration.md

## Changes

- **New**: `internal/ui/parallel_progress.go` - Multi-line animated progress component
- **Updated**: `internal/parallel/output.go` - Integrates animated progress for TTY mode
- **Docs**: README now has dedicated "Parallel execution" section with examples
- **Docs**: configuration.md documents all parallel task fields and CLI flags

## Test plan

- [x] Unit tests for ParallelProgress component
- [x] Existing parallel execution tests pass
- [x] Lint passes
- [ ] Manual verification of animation in terminal

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel task execution with animated progress indicators displayed in real-time.
  * Live status indicators showing per-host task timings and execution summary.
  * New task lifecycle states (syncing and executing) for improved progress visibility.
  * Additional CLI flags for parallel execution control: `--stream`, `--verbose`, `--quiet`, `--fail-fast`, `--max-parallel`, `--dry-run`, `--local`, and `--no-logs`.
  * Updated load balancing behavior for single vs. parallel task distribution.

* **Documentation**
  * Added comprehensive parallel execution section to README with configuration examples and output samples.
  * Extended configuration documentation with parallel task examples and execution behavior details.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->