### PR TITLE
fix: respect host priority order for single task execution

### DIFF
--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -47,8 +47,14 @@ func Sync(opts SyncOptions) error {
 		}
 	}
 
-	// Create host selector from global hosts
-	selector := host.NewSelector(resolved.Global.Hosts)
+	// Create host selector with proper priority order
+	hostOrder, projectHosts, err := config.ResolveHosts(resolved, opts.Host)
+	if err != nil {
+		// Fall back to all global hosts if resolution fails
+		projectHosts = resolved.Global.Hosts
+	}
+	selector := host.NewSelector(projectHosts)
+	selector.SetHostOrder(hostOrder)
 	defer selector.Close()
 
 	// Set probe timeout (CLI flag overrides config)

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -125,12 +125,13 @@ func setupHostSelector(ctx *WorkflowContext, opts WorkflowOptions) {
 	// Get the hosts this project is allowed to use
 	// (respects project.Hosts list if specified, otherwise uses all global hosts)
 	// Empty hosts with nil error indicates local-only mode
-	_, projectHosts, err := config.ResolveHosts(ctx.Resolved, opts.Host)
+	hostOrder, projectHosts, err := config.ResolveHosts(ctx.Resolved, opts.Host)
 	if err != nil {
 		// Fall back to all global hosts if resolution fails
 		ctx.selector = host.NewSelector(ctx.Resolved.Global.Hosts)
 	} else {
 		ctx.selector = host.NewSelector(projectHosts)
+		ctx.selector.SetHostOrder(hostOrder)
 	}
 	ctx.selector.SetLocalFallback(localFallback)
 


### PR DESCRIPTION
## Summary
- Fixes host selection to respect the priority order from .rr.yaml config
- Previously hosts were sorted alphabetically, ignoring user-defined priority
- Adds `SetHostOrder` method to Selector and uses it in workflow/sync

## Problem
With hosts configured as:
```yaml
hosts:
  - m4-mini
  - m1-linux
  - m1-mini
```

The selector was picking `m1-linux` first (alphabetically) instead of `m4-mini` (first in config).

## Test Plan
- [x] Added unit tests for `SetHostOrder` and priority-based resolution
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hosts can now be selected based on an explicit priority order defined in configuration. This provides greater flexibility in managing host availability and selection. When configuration resolution is unavailable, the system automatically falls back to global hosts, ensuring reliability.

* **Tests**
  * Added comprehensive unit tests for host priority ordering and resolution behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->