### PR TITLE
fix: GetHostNames respects hostOrder for load-balanced workflows

### DIFF
--- a/internal/host/selector_test.go
+++ b/internal/host/selector_test.go
@@ -1180,6 +1180,54 @@ func TestSelector_GetHostNames_Sorted(t *testing.T) {
 	}
 }
 
+func TestSelector_GetHostNames_UsesHostOrder(t *testing.T) {
+	hosts := map[string]config.Host{
+		"zebra": {SSH: []string{"localhost"}},
+		"apple": {SSH: []string{"localhost"}},
+		"mango": {SSH: []string{"localhost"}},
+	}
+
+	selector := NewSelector(hosts)
+	// Set custom order (non-alphabetical)
+	selector.SetHostOrder([]string{"mango", "zebra", "apple"})
+	names := selector.GetHostNames()
+
+	expected := []string{"mango", "zebra", "apple"}
+	if len(names) != len(expected) {
+		t.Fatalf("GetHostNames() returned %d names, want %d", len(names), len(expected))
+	}
+
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("GetHostNames()[%d] = %q, want %q", i, name, expected[i])
+		}
+	}
+}
+
+func TestSelector_GetHostNames_HostOrderFiltersNonExistent(t *testing.T) {
+	hosts := map[string]config.Host{
+		"zebra": {SSH: []string{"localhost"}},
+		"apple": {SSH: []string{"localhost"}},
+	}
+
+	selector := NewSelector(hosts)
+	// Set order with a non-existent host
+	selector.SetHostOrder([]string{"mango", "zebra", "nonexistent", "apple"})
+	names := selector.GetHostNames()
+
+	// Should only return hosts that exist
+	expected := []string{"zebra", "apple"}
+	if len(names) != len(expected) {
+		t.Fatalf("GetHostNames() returned %d names, want %d", len(names), len(expected))
+	}
+
+	for i, name := range names {
+		if name != expected[i] {
+			t.Errorf("GetHostNames()[%d] = %q, want %q", i, name, expected[i])
+		}
+	}
+}
+
 // ============================================================================
 // SelectHost tests
 // ============================================================================


### PR DESCRIPTION
## Summary
Fixes host priority for load-balanced workflows (multi-host scenarios).

## Root Cause
`GetHostNames()` was returning hosts in alphabetical order, but the load-balanced workflow (`findAvailableHost`) uses this to iterate through hosts. This caused `m1-linux` to be tried before `m4-mini` even though `m4-mini` was first in the config.

## Fix
Updated `GetHostNames()` to return hosts in `hostOrder` when set, matching `resolveHost()` behavior.

## Test Plan
- [x] Added unit tests for `GetHostNames` with hostOrder
- [x] Manual test confirms m4-mini is now selected first

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Host selection now prioritizes user-configured ordering when available; defaults to alphabetical order for consistency when no custom configuration is specified.
  * Enhanced host selection to filter and include only existing hosts.

* **Tests**
  * Added tests validating host ordering behavior and filtering of non-existent hosts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->