### PR TITLE
feat: add visual status indicators for host lock state in monitor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,8 +42,15 @@ jobs:
         run: |
           # Run tests with JSON output to file only (quiet on success)
           if ! go test -race -coverprofile=coverage.out -covermode=atomic -json ./... > test-results.json 2>&1; then
-            echo "Tests failed. Output:"
-            jq -rs '[.[] | select(.Action=="output")] | map(.Output) | join("")' test-results.json
+            echo "Tests failed. Showing failures only:"
+            echo ""
+            # Get list of failed tests and their output
+            FAILED_TESTS=$(jq -r 'select(.Action=="fail" and .Test != null) | .Test' test-results.json | sort -u)
+            for test in $FAILED_TESTS; do
+              echo "=== FAIL: $test ==="
+              jq -rs --arg t "$test" '[.[] | select(.Test==$t and .Action=="output")] | map(.Output) | join("")' test-results.json
+              echo ""
+            done
             exit 1
           fi
           echo "All tests passed"
@@ -173,7 +180,18 @@ jobs:
           RR_TEST_SSH_KEY: /tmp/rr-ci-ssh-keys/id_ed25519
           RR_TEST_SSH_USER: testuser
         run: |
-          go test -v -race -coverprofile=coverage-integration.out -covermode=atomic ./tests/integration/... ./pkg/sshutil/...
+          if ! go test -race -coverprofile=coverage-integration.out -covermode=atomic -json ./tests/integration/... ./pkg/sshutil/... > integration-results.json 2>&1; then
+            echo "Integration tests failed. Showing failures only:"
+            echo ""
+            FAILED_TESTS=$(jq -r 'select(.Action=="fail" and .Test != null) | .Test' integration-results.json | sort -u)
+            for test in $FAILED_TESTS; do
+              echo "=== FAIL: $test ==="
+              jq -rs --arg t "$test" '[.[] | select(.Test==$t and .Action=="output")] | map(.Output) | join("")' integration-results.json
+              echo ""
+            done
+            exit 1
+          fi
+          echo "All integration tests passed"
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v6

--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -57,6 +58,15 @@ func monitorCommand(hostsFilter string, interval time.Duration) error {
 
 	// Create collector from filtered hosts
 	collector := monitor.NewCollector(hosts)
+
+	// Configure lock checking if we have a project config with locking enabled
+	if resolved.Project != nil && resolved.Project.Lock.Enabled {
+		workDir, err := os.Getwd()
+		if err == nil {
+			projectHash := hashProject(workDir)
+			collector.SetLockConfig(resolved.Project.Lock, projectHash)
+		}
+	}
 
 	// Create Bubble Tea model with host order for default sorting
 	model := monitor.NewModel(collector, interval, hostOrder)

--- a/internal/monitor/card.go
+++ b/internal/monitor/card.go
@@ -229,27 +229,35 @@ func (m Model) renderCard(host string, width int, selected bool) string {
 	return style.Render(content)
 }
 
-// renderHostLine renders the host name with status indicator.
+// renderHostLine renders the host name with status indicator and status text.
 func (m Model) renderHostLine(host string, status HostStatus) string {
 	var indicator string
 	var indicatorStyle lipgloss.Style
+	var statusText string
 
 	switch status {
 	case StatusConnectingState:
 		indicator = m.ConnectingSpinner() // Animated spinner
 		indicatorStyle = StatusConnectingStyle
-	case StatusConnectedState:
-		indicator = StatusConnected
-		indicatorStyle = StatusConnectedStyle
+		// No status text for connecting - card content shows the message
+	case StatusIdleState:
+		indicator = StatusIdle
+		indicatorStyle = StatusIdleStyle
+		statusText = StatusTextStyle.Render(" - idle")
+	case StatusRunningState:
+		indicator, indicatorStyle = m.RunningSpinner() // Animated braille spinner with color cycling
+		statusText = m.renderRunningStatusText(host)
 	case StatusSlowState:
-		indicator = StatusConnected
+		indicator = StatusIdle
 		indicatorStyle = StatusSlowStyle
+		statusText = StatusTextStyle.Render(" - slow")
 	case StatusUnreachableState:
 		indicator = StatusUnreachable
 		indicatorStyle = StatusUnreachableStyle
+		statusText = StatusTextStyle.Render(" - offline")
 	}
 
-	return indicatorStyle.Render(indicator) + " " + HostNameStyle.Render(host)
+	return indicatorStyle.Render(indicator) + " " + HostNameStyle.Render(host) + statusText
 }
 
 // renderCardCPUSection renders CPU with a braille sparkline graph.
@@ -646,6 +654,7 @@ func (m Model) renderMinimalCard(host string, width int, selected bool) string {
 }
 
 // renderMinimalHostLine renders the hostname, truncating if necessary.
+// Minimal mode doesn't show status text to save space.
 func (m Model) renderMinimalHostLine(host string, status HostStatus, maxWidth int) string {
 	var indicator string
 	var indicatorStyle lipgloss.Style
@@ -654,11 +663,13 @@ func (m Model) renderMinimalHostLine(host string, status HostStatus, maxWidth in
 	case StatusConnectingState:
 		indicator = m.ConnectingSpinner() // Animated spinner
 		indicatorStyle = StatusConnectingStyle
-	case StatusConnectedState:
-		indicator = StatusConnected
-		indicatorStyle = StatusConnectedStyle
+	case StatusIdleState:
+		indicator = StatusIdle
+		indicatorStyle = StatusIdleStyle
+	case StatusRunningState:
+		indicator, indicatorStyle = m.RunningSpinner() // Animated braille spinner
 	case StatusSlowState:
-		indicator = StatusConnected
+		indicator = StatusIdle
 		indicatorStyle = StatusSlowStyle
 	case StatusUnreachableState:
 		indicator = StatusUnreachable

--- a/internal/monitor/card_test.go
+++ b/internal/monitor/card_test.go
@@ -188,7 +188,7 @@ func TestModel_renderHostLine(t *testing.T) {
 		host   string
 		status HostStatus
 	}{
-		{"connected", "server1", StatusConnectedState},
+		{"idle", "server1", StatusIdleState},
 		{"slow", "server1", StatusSlowState},
 		{"unreachable", "server1", StatusUnreachableState},
 	}
@@ -234,7 +234,7 @@ func TestModel_renderCard(t *testing.T) {
 						{PID: 1234, User: "root", CPU: 25.0, Memory: 10.0, Command: "/usr/bin/process"},
 					},
 				}
-				m.status[tt.host] = StatusConnectedState
+				m.status[tt.host] = StatusIdleState
 			}
 
 			result := m.renderCard(tt.host, tt.width, tt.selected)
@@ -269,7 +269,7 @@ func TestModel_renderCompactCard(t *testing.T) {
 					CPU: CPUMetrics{Percent: 50.0},
 					RAM: RAMMetrics{UsedBytes: 4000000000, TotalBytes: 8000000000},
 				}
-				m.status["server1"] = StatusConnectedState
+				m.status["server1"] = StatusIdleState
 			}
 
 			result := m.renderCompactCard("server1", 80, tt.selected)
@@ -302,7 +302,7 @@ func TestModel_renderMinimalCard(t *testing.T) {
 					CPU: CPUMetrics{Percent: 50.0},
 					RAM: RAMMetrics{UsedBytes: 4000000000, TotalBytes: 8000000000},
 				}
-				m.status["server1"] = StatusConnectedState
+				m.status["server1"] = StatusIdleState
 			}
 
 			result := m.renderMinimalCard("server1", 50, false)
@@ -330,7 +330,7 @@ func TestModel_renderMinimalHostLine(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := m.renderMinimalHostLine(tt.host, StatusConnectedState, tt.maxWidth)
+			result := m.renderMinimalHostLine(tt.host, StatusIdleState, tt.maxWidth)
 			assert.NotEmpty(t, result)
 		})
 	}

--- a/internal/monitor/detail.go
+++ b/internal/monitor/detail.go
@@ -33,17 +33,24 @@ const (
 func (m Model) renderDetailHeader(host string, status HostStatus) string {
 	var indicator string
 	var indicatorStyle lipgloss.Style
+	var statusLabel string
 
 	switch status {
-	case StatusConnectedState:
-		indicator = StatusConnected + " Connected"
-		indicatorStyle = StatusConnectedStyle
+	case StatusIdleState:
+		indicator = StatusIdle
+		indicatorStyle = StatusIdleStyle
+		statusLabel = " Idle"
+	case StatusRunningState:
+		indicator, indicatorStyle = m.RunningSpinner()
+		statusLabel = " Running"
 	case StatusSlowState:
-		indicator = StatusConnected + " Slow"
+		indicator = StatusIdle
 		indicatorStyle = StatusSlowStyle
+		statusLabel = " Slow"
 	case StatusUnreachableState:
-		indicator = StatusUnreachable + " Unreachable"
+		indicator = StatusUnreachable
 		indicatorStyle = StatusUnreachableStyle
+		statusLabel = " Offline"
 	}
 
 	hostTitle := lipgloss.NewStyle().
@@ -51,7 +58,7 @@ func (m Model) renderDetailHeader(host string, status HostStatus) string {
 		Bold(true).
 		Render(host)
 
-	statusText := indicatorStyle.Render(indicator)
+	statusText := indicatorStyle.Render(indicator + statusLabel)
 
 	return fmt.Sprintf("%s  %s", hostTitle, statusText)
 }

--- a/internal/monitor/detail_test.go
+++ b/internal/monitor/detail_test.go
@@ -66,7 +66,7 @@ func TestModel_renderDetailHeader(t *testing.T) {
 		host   string
 		status HostStatus
 	}{
-		{"connected", "server1", StatusConnectedState},
+		{"idle", "server1", StatusIdleState},
 		{"slow", "server1", StatusSlowState},
 		{"unreachable", "server1", StatusUnreachableState},
 	}
@@ -363,7 +363,7 @@ func TestModel_renderDetailViewWithViewport(t *testing.T) {
 					}
 				}
 				m.metrics["server1"] = metrics
-				m.status["server1"] = StatusConnectedState
+				m.status["server1"] = StatusIdleState
 			}
 
 			if tt.wideLayout {

--- a/internal/monitor/model_test.go
+++ b/internal/monitor/model_test.go
@@ -44,9 +44,10 @@ func TestHostStatus_String(t *testing.T) {
 		expect string
 	}{
 		{StatusConnectingState, "connecting"},
-		{StatusConnectedState, "connected"},
+		{StatusIdleState, "idle"},
+		{StatusRunningState, "running"},
 		{StatusSlowState, "slow"},
-		{StatusUnreachableState, "unreachable"},
+		{StatusUnreachableState, "offline"},
 		{HostStatus(99), "unknown"},
 	}
 
@@ -71,11 +72,11 @@ func TestModel_OnlineCount(t *testing.T) {
 	assert.Equal(t, 0, m.OnlineCount())
 
 	// Mark one as connected
-	m.status["server1"] = StatusConnectedState
+	m.status["server1"] = StatusIdleState
 	assert.Equal(t, 1, m.OnlineCount())
 
 	// Mark another as connected
-	m.status["server2"] = StatusConnectedState
+	m.status["server2"] = StatusIdleState
 	assert.Equal(t, 2, m.OnlineCount())
 
 	// Mark one as slow (not counted as online)
@@ -141,10 +142,10 @@ func TestModel_updateMetrics(t *testing.T) {
 		"server2": "connection refused",
 	}
 
-	m.updateMetrics(metrics, errors)
+	m.updateMetrics(metrics, errors, nil)
 
 	// Server1 should be connected
-	assert.Equal(t, StatusConnectedState, m.status["server1"])
+	assert.Equal(t, StatusIdleState, m.status["server1"])
 	assert.NotNil(t, m.metrics["server1"])
 	_, hasError := m.errors["server1"]
 	assert.False(t, hasError)

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -79,20 +79,31 @@ var (
 	StatusConnectingStyle = lipgloss.NewStyle().
 				Foreground(ColorTextSecondary)
 
-	StatusConnectedStyle = lipgloss.NewStyle().
-				Foreground(ColorHealthy)
+	StatusIdleStyle = lipgloss.NewStyle().
+			Foreground(ColorHealthy)
+
+	StatusRunningStyle = lipgloss.NewStyle().
+				Foreground(ColorWarning)
 
 	StatusSlowStyle = lipgloss.NewStyle().
 			Foreground(ColorWarning)
 
 	StatusUnreachableStyle = lipgloss.NewStyle().
 				Foreground(ColorCritical)
+
+	// Status text styles (for the "- idle", "- running" suffix)
+	StatusTextStyle = lipgloss.NewStyle().
+			Foreground(ColorTextMuted)
+
+	StatusRunningTextStyle = lipgloss.NewStyle().
+				Foreground(ColorWarning)
 )
 
 // Status indicator characters - cyber glyphs
 const (
 	StatusConnecting  = "◐" // Half-filled (used as fallback when animation not available)
-	StatusConnected   = "◉" // Filled target
+	StatusIdle        = "◉" // Filled target - ready for work
+	StatusRunning     = "⣿" // Braille full (used as fallback when animation not available)
 	StatusUnreachable = "◌" // Dashed circle
 	StatusSlow        = "◔" // Partially filled
 )
@@ -100,6 +111,23 @@ const (
 // ConnectingSpinnerFrames are the animation frames for the connecting state
 // Rotates through half-circle positions for a smooth spin effect
 var ConnectingSpinnerFrames = []string{"◐", "◓", "◑", "◒"}
+
+// RunningSpinnerFrames are the animation frames for the running/locked state
+// Uses braille dots for a subtle "working" animation
+var RunningSpinnerFrames = []string{"⣾", "⣽", "⣻", "⢿", "⡿", "⣟", "⣯", "⣷"}
+
+// SpinnerColorFrames defines the gen-z color cycling for animated spinners
+// Cycles through neon colors for a vibrant effect
+var SpinnerColorFrames = []lipgloss.Color{
+	lipgloss.Color("#FFAA00"), // Electric amber
+	lipgloss.Color("#FF8800"), // Orange
+	lipgloss.Color("#FFCC00"), // Gold
+	lipgloss.Color("#FFAA00"), // Electric amber
+	lipgloss.Color("#FF9900"), // Amber-orange
+	lipgloss.Color("#FFBB00"), // Yellow-amber
+	lipgloss.Color("#FFAA00"), // Electric amber
+	lipgloss.Color("#FF7700"), // Deep amber
+}
 
 // ConnectingTextFrames are the animated text frames for the connecting message
 var ConnectingTextFrames = []string{
@@ -115,6 +143,20 @@ var ConnectingSubtextFrames = []string{
 	"establishing connection",
 	"waiting for response",
 	"almost there",
+}
+
+// GetSpinnerColor returns the color for the current spinner frame index.
+// Used for gen-z style color cycling on animated spinners.
+func GetSpinnerColor(frameIndex int) lipgloss.Color {
+	return SpinnerColorFrames[frameIndex%len(SpinnerColorFrames)]
+}
+
+// GetRunningSpinner returns the spinner character and style for the running state.
+func GetRunningSpinner(frameIndex int) (string, lipgloss.Style) {
+	char := RunningSpinnerFrames[frameIndex%len(RunningSpinnerFrames)]
+	color := GetSpinnerColor(frameIndex)
+	style := lipgloss.NewStyle().Foreground(color)
+	return char, style
 }
 
 // MetricColor returns the appropriate color for a percentage-based metric.

--- a/internal/monitor/styles_test.go
+++ b/internal/monitor/styles_test.go
@@ -264,7 +264,8 @@ func TestThresholdConstants(t *testing.T) {
 }
 
 func TestStatusIndicatorConstants(t *testing.T) {
-	assert.Equal(t, "◉", StatusConnected)   // Cyber glyph
+	assert.Equal(t, "◉", StatusIdle)        // Filled target - ready for work
+	assert.Equal(t, "⣿", StatusRunning)     // Braille full - active
 	assert.Equal(t, "◌", StatusUnreachable) // Cyber glyph
 	assert.Equal(t, "◔", StatusSlow)        // Cyber glyph
 }
@@ -283,4 +284,46 @@ func TestColorConstants(t *testing.T) {
 	assert.NotEmpty(t, string(ColorAccent))
 	assert.NotEmpty(t, string(ColorAccentDim))
 	assert.NotEmpty(t, string(ColorGraph))
+}
+
+func TestRunningSpinnerFrames(t *testing.T) {
+	// Verify running spinner frames are defined
+	assert.Len(t, RunningSpinnerFrames, 8)
+	// Verify they're braille characters
+	for _, frame := range RunningSpinnerFrames {
+		assert.NotEmpty(t, frame)
+	}
+}
+
+func TestSpinnerColorFrames(t *testing.T) {
+	// Verify spinner color frames are defined
+	assert.Len(t, SpinnerColorFrames, 8)
+	for _, color := range SpinnerColorFrames {
+		assert.NotEmpty(t, string(color))
+	}
+}
+
+func TestGetSpinnerColor(t *testing.T) {
+	// Verify color cycling works
+	for i := 0; i < 16; i++ {
+		color := GetSpinnerColor(i)
+		assert.NotEmpty(t, string(color))
+	}
+	// Verify it wraps around
+	assert.Equal(t, GetSpinnerColor(0), GetSpinnerColor(8))
+	assert.Equal(t, GetSpinnerColor(1), GetSpinnerColor(9))
+}
+
+func TestGetRunningSpinner(t *testing.T) {
+	// Test each frame
+	for i := 0; i < 8; i++ {
+		char, style := GetRunningSpinner(i)
+		assert.Equal(t, RunningSpinnerFrames[i], char)
+		assert.NotNil(t, style)
+	}
+
+	// Test wrapping
+	char0, _ := GetRunningSpinner(0)
+	char8, _ := GetRunningSpinner(8)
+	assert.Equal(t, char0, char8)
 }

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -64,3 +64,51 @@ type SystemInfo struct {
 	Kernel   string
 	Uptime   time.Duration
 }
+
+// HostLockInfo contains lock status for a host.
+type HostLockInfo struct {
+	IsLocked bool      // True if a lock is held on this host
+	Holder   string    // Description of who holds the lock (user@host)
+	Started  time.Time // When the lock was acquired
+}
+
+// Duration returns how long the lock has been held.
+func (l HostLockInfo) Duration() time.Duration {
+	if l.Started.IsZero() {
+		return 0
+	}
+	return time.Since(l.Started)
+}
+
+// FormatDuration returns a human-readable duration string (e.g., "2m30s").
+func (l HostLockInfo) FormatDuration() string {
+	d := l.Duration()
+	if d < time.Second {
+		return "0s"
+	}
+	// Format as Xm or XmYs
+	minutes := int(d.Minutes())
+	seconds := int(d.Seconds()) % 60
+	if minutes > 0 {
+		if seconds > 0 {
+			return formatInt(minutes) + "m" + formatInt(seconds) + "s"
+		}
+		return formatInt(minutes) + "m"
+	}
+	return formatInt(seconds) + "s"
+}
+
+// formatInt converts an integer to a string without importing strconv.
+func formatInt(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var buf [20]byte
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/internal/monitor/view_test.go
+++ b/internal/monitor/view_test.go
@@ -363,7 +363,7 @@ func TestModel_renderHeader(t *testing.T) {
 	m.height = 40
 
 	// Mark one host as connected
-	m.status["server1"] = StatusConnectedState
+	m.status["server1"] = StatusIdleState
 
 	result := m.renderHeader()
 	assert.NotEmpty(t, result)


### PR DESCRIPTION
## Summary
- Add expressive host states in `rr monitor`: idle (green), running (amber animated), offline (red)
- Running state shows animated braille spinner with gen-z style color cycling
- Display lock duration when host is actively running a task (e.g., "running 2m30s")
- Add lock status checking to monitor collector

## Changes
| State | Symbol | Color | Display |
|-------|--------|-------|---------|
| Connecting | ◐◓◑◒ | Gray | Animated spinner |
| Idle | ◉ | Green | "◉ m4-mini - idle" |
| Running | ⣾⣽⣻⢿⡿⣟⣯⣷ | Amber (cycling) | "◉ m4-mini - running 2m30s" |
| Offline | ◌ | Red | "◌ m4-mini - offline" |

## Other Changes
- Refactor host selector to use `orderedHostNames` helper (reduces duplication)
- Improve CI test output to show only failing tests (cleaner output)

## Test plan
- [x] All unit tests pass
- [x] Lint passes
- [ ] Manual testing with `rr monitor`

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Host status now displays descriptive labels (Idle, Running, Slow, Offline)
- Added running state tracking with duration display for active tasks
- Introduced animated visual indicator for actively running hosts

**Bug Fixes**
- Improved CI/CD failure reporting to show detailed test and integration test failures
- Fixed host ordering consistency across host list and selection

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->