### PR TITLE
refactor: implement per-host locking instead of per-project locking

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 	"time"
@@ -61,11 +60,7 @@ func monitorCommand(hostsFilter string, interval time.Duration) error {
 
 	// Configure lock checking if we have a project config with locking enabled
 	if resolved.Project != nil && resolved.Project.Lock.Enabled {
-		workDir, err := os.Getwd()
-		if err == nil {
-			projectHash := hashProject(workDir)
-			collector.SetLockConfig(resolved.Project.Lock, projectHash)
-		}
+		collector.SetLockConfig(resolved.Project.Lock)
 	}
 
 	// Create Bubble Tea model with host order for default sorting

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -313,9 +313,8 @@ func lockPhase(ctx *WorkflowContext, opts WorkflowOptions) error {
 	lockSpinner := ui.NewSpinner("Acquiring lock")
 	lockSpinner.Start()
 
-	projectHash := hashProject(ctx.WorkDir)
 	var err error
-	ctx.Lock, err = lock.Acquire(ctx.Conn, lockCfg, projectHash)
+	ctx.Lock, err = lock.Acquire(ctx.Conn, lockCfg)
 	if err != nil {
 		lockSpinner.Fail()
 		return err

--- a/internal/parallel/worker.go
+++ b/internal/parallel/worker.go
@@ -165,8 +165,7 @@ func (w *hostWorker) ensureSync(_ context.Context) error {
 	}
 
 	if lockCfg.Enabled && w.conn != nil {
-		projectHash := hashWorkDir(workDir)
-		hostLock, err := lock.Acquire(w.conn, lockCfg, projectHash)
+		hostLock, err := lock.Acquire(w.conn, lockCfg)
 		if err != nil {
 			return err
 		}
@@ -274,17 +273,6 @@ func (w *hostWorker) Close() error {
 		return err
 	}
 	return nil
-}
-
-// hashWorkDir creates a hash of the working directory for lock naming.
-func hashWorkDir(workDir string) string {
-	// Use a simple hash for the project identifier
-	// This matches how the CLI does it in workflow.go
-	h := uint32(0)
-	for _, c := range workDir {
-		h = h*31 + uint32(c)
-	}
-	return string(rune('a'+h%26)) + string(rune('a'+(h>>5)%26)) + string(rune('a'+(h>>10)%26)) + string(rune('a'+(h>>15)%26))
 }
 
 // localWorker executes tasks locally without SSH.

--- a/tests/integration/exec_ssh_test.go
+++ b/tests/integration/exec_ssh_test.go
@@ -182,8 +182,7 @@ func TestFullWorkflowSyncLockExec(t *testing.T) {
 		Timeout: 5 * time.Second,
 		Stale:   1 * time.Hour,
 	}
-	projectHash := fmt.Sprintf("workflow-%d", time.Now().UnixNano())
-	lck, err := lock.TryAcquire(conn, lockCfg, projectHash)
+	lck, err := lock.TryAcquire(conn, lockCfg)
 	require.NoError(t, err, "Lock acquisition should succeed")
 	defer lck.Release()
 

--- a/tests/integration/mvp_test.go
+++ b/tests/integration/mvp_test.go
@@ -253,7 +253,7 @@ func TestLockAcquireRequiresConnection(t *testing.T) {
 	}
 
 	// Acquire should fail without a connection
-	_, err := lock.Acquire(nil, cfg, "test-project-hash")
+	_, err := lock.Acquire(nil, cfg)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Can't grab the lock")
 }


### PR DESCRIPTION
## Summary
- Changed lock system from project-specific locks (`/tmp/rr-<hash>.lock`) to a single per-host lock (`/tmp/rr.lock`)
- This ensures only one rr task runs on a host at a time regardless of which project initiated it
- Better reflects that remote execution is resource-intensive and should be exclusive per host

## Changes
- Remove `projectHash` parameter from `Acquire`, `TryAcquire`, `IsLocked`, `GetLockHolder`
- Add `LockDir()` helper function for consistent lock path generation
- Simplify lock status checking in monitor (now checks for any rr lock)
- Update all callers to use new function signatures

## Test plan
- [x] Unit tests pass
- [x] Integration tests updated and pass
- [x] Build succeeds

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified locking mechanism to use a single host-wide lock instead of per-project locks, providing consistent behavior across all projects running on the same host.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->