### PR TITLE
fix: track parallel tasks by index to handle duplicate task names

### DIFF
--- a/internal/cli/parallel.go
+++ b/internal/cli/parallel.go
@@ -58,7 +58,7 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 
 	// Build TaskInfo for each subtask
 	tasks := make([]parallel.TaskInfo, 0, len(task.Parallel))
-	for _, subtaskName := range task.Parallel {
+	for i, subtaskName := range task.Parallel {
 		subtask, err := config.GetTask(resolved.Project, subtaskName)
 		if err != nil {
 			return 1, err
@@ -73,6 +73,7 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 
 		tasks = append(tasks, parallel.TaskInfo{
 			Name:    subtaskName,
+			Index:   i, // Unique index for duplicate name handling
 			Command: cmd,
 			Env:     subtask.Env,
 		})
@@ -184,7 +185,8 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 	// Write task outputs to logs
 	if logWriter != nil {
 		for i := range result.TaskResults {
-			_ = logWriter.WriteTask(result.TaskResults[i].TaskName, result.TaskResults[i].Output)
+			tr := &result.TaskResults[i]
+			_ = logWriter.WriteTask(tr.TaskName, tr.TaskIndex, tr.Output)
 		}
 		_ = logWriter.WriteSummary(result, opts.TaskName)
 		_ = logWriter.Close()

--- a/internal/parallel/orchestrator.go
+++ b/internal/parallel/orchestrator.go
@@ -91,12 +91,8 @@ func (o *Orchestrator) Run(ctx context.Context) (*Result, error) {
 	o.outputMgr = NewOutputManager(o.config.OutputMode, isTTY)
 	defer o.outputMgr.Close()
 
-	// Show all tasks as pending upfront
-	taskNames := make([]string, len(o.tasks))
-	for i, t := range o.tasks {
-		taskNames[i] = t.Name
-	}
-	o.outputMgr.InitTasks(taskNames)
+	// Show all tasks as pending upfront (pass full TaskInfo for Index tracking)
+	o.outputMgr.InitTasks(o.tasks)
 
 	startTime := time.Now()
 
@@ -264,12 +260,8 @@ func (o *Orchestrator) runLocal(ctx context.Context) (*Result, error) {
 	o.outputMgr = NewOutputManager(o.config.OutputMode, isTTY)
 	defer o.outputMgr.Close()
 
-	// Show all tasks as pending upfront
-	taskNames := make([]string, len(o.tasks))
-	for i, t := range o.tasks {
-		taskNames[i] = t.Name
-	}
-	o.outputMgr.InitTasks(taskNames)
+	// Show all tasks as pending upfront (pass full TaskInfo for Index tracking)
+	o.outputMgr.InitTasks(o.tasks)
 
 	startTime := time.Now()
 

--- a/internal/parallel/types.go
+++ b/internal/parallel/types.go
@@ -1,6 +1,9 @@
 package parallel
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // OutputMode controls how parallel task output is displayed.
 type OutputMode string
@@ -55,6 +58,7 @@ func (r *Result) Success() bool {
 // TaskResult holds the result of a single task execution.
 type TaskResult struct {
 	TaskName  string
+	TaskIndex int    // Position in task list (for duplicate name handling)
 	Command   string // Original command (for formatter detection)
 	Host      string
 	ExitCode  int
@@ -63,6 +67,11 @@ type TaskResult struct {
 	Output    []byte // Captured stdout+stderr for summary
 	StartTime time.Time
 	EndTime   time.Time
+}
+
+// ID returns a unique identifier for this task result.
+func (r *TaskResult) ID() string {
+	return taskID(r.TaskName, r.TaskIndex)
 }
 
 // Success returns true if the task passed (exit code 0).
@@ -102,7 +111,18 @@ func (s TaskStatus) String() string {
 // TaskInfo represents a task to be executed with its resolved configuration.
 type TaskInfo struct {
 	Name    string            // Task name from config
+	Index   int               // Position in task list (for duplicate name handling)
 	Command string            // Command to execute
 	Env     map[string]string // Environment variables
 	WorkDir string            // Working directory on remote
+}
+
+// ID returns a unique identifier for this task.
+func (t TaskInfo) ID() string {
+	return taskID(t.Name, t.Index)
+}
+
+// taskID creates a unique task identifier from name and index.
+func taskID(name string, index int) string {
+	return fmt.Sprintf("%s#%d", name, index)
 }

--- a/internal/ui/parallel_progress_test.go
+++ b/internal/ui/parallel_progress_test.go
@@ -14,7 +14,7 @@ func TestParallelProgress_TaskStarted(t *testing.T) {
 	p.SetWriter(&buf)
 	p.Start()
 
-	p.TaskStarted("build", "m1-linux")
+	p.TaskStarted("build", 0, "m1-linux")
 
 	// Give animation a tick to render
 	time.Sleep(100 * time.Millisecond)
@@ -32,8 +32,8 @@ func TestParallelProgress_TaskCompleted(t *testing.T) {
 	p.SetWriter(&buf)
 	p.Start()
 
-	p.TaskStarted("test", "dev")
-	p.TaskCompleted("test", true)
+	p.TaskStarted("test", 0, "dev")
+	p.TaskCompleted("test", 0, true)
 
 	// Give animation a tick to render
 	time.Sleep(100 * time.Millisecond)
@@ -51,8 +51,8 @@ func TestParallelProgress_TaskFailed(t *testing.T) {
 	p.SetWriter(&buf)
 	p.Start()
 
-	p.TaskStarted("lint", "server")
-	p.TaskCompleted("lint", false)
+	p.TaskStarted("lint", 0, "server")
+	p.TaskCompleted("lint", 0, false)
 
 	// Give animation a tick
 	time.Sleep(100 * time.Millisecond)
@@ -71,17 +71,17 @@ func TestParallelProgress_MultipleTasks(t *testing.T) {
 	p.Start()
 
 	// Start multiple tasks
-	p.TaskStarted("test-backend", "m1-linux")
-	p.TaskStarted("test-frontend", "m1-mini")
-	p.TaskStarted("test-opendata", "m4-mini")
+	p.TaskStarted("test-backend", 0, "m1-linux")
+	p.TaskStarted("test-frontend", 1, "m1-mini")
+	p.TaskStarted("test-opendata", 2, "m4-mini")
 
 	// Give animation a tick
 	time.Sleep(100 * time.Millisecond)
 
 	// Complete tasks in different order
-	p.TaskCompleted("test-frontend", true)
-	p.TaskCompleted("test-opendata", true)
-	p.TaskCompleted("test-backend", true)
+	p.TaskCompleted("test-frontend", 1, true)
+	p.TaskCompleted("test-opendata", 2, true)
+	p.TaskCompleted("test-backend", 0, true)
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -105,10 +105,10 @@ func TestParallelProgress_HasRunningTasks(t *testing.T) {
 
 	assert.False(t, p.HasRunningTasks())
 
-	p.TaskStarted("task1", "host1")
+	p.TaskStarted("task1", 0, "host1")
 	assert.True(t, p.HasRunningTasks())
 
-	p.TaskCompleted("task1", true)
+	p.TaskCompleted("task1", 0, true)
 	assert.False(t, p.HasRunningTasks())
 }
 
@@ -118,7 +118,7 @@ func TestParallelProgress_NonTTY(t *testing.T) {
 	p.SetWriter(&buf)
 	p.Start()
 
-	p.TaskStarted("test", "dev")
+	p.TaskStarted("test", 0, "dev")
 
 	time.Sleep(100 * time.Millisecond)
 
@@ -135,7 +135,7 @@ func TestParallelProgress_AnimationFrames(t *testing.T) {
 	p.SetWriter(&buf)
 	p.Start()
 
-	p.TaskStarted("build", "host")
+	p.TaskStarted("build", 0, "host")
 
 	// Let multiple animation frames render
 	time.Sleep(300 * time.Millisecond)
@@ -151,4 +151,57 @@ func TestParallelProgress_AnimationFrames(t *testing.T) {
 	// Should also contain task info
 	assert.Contains(t, output, "build")
 	assert.Contains(t, output, "[host]")
+}
+
+// TestParallelProgress_DuplicateTaskNames verifies that tasks with the same name
+// but different indices are tracked and updated separately.
+func TestParallelProgress_DuplicateTaskNames(t *testing.T) {
+	var buf bytes.Buffer
+	p := NewParallelProgress(true)
+	p.SetWriter(&buf)
+	p.Start()
+
+	// Initialize three tasks with the same name
+	p.InitTasks([]TaskInit{
+		{Name: "test-opendata", Index: 0},
+		{Name: "test-opendata", Index: 1},
+		{Name: "test-opendata", Index: 2},
+	})
+
+	// Give animation a tick
+	time.Sleep(100 * time.Millisecond)
+
+	// Start syncing each (they go to different hosts)
+	p.TaskSyncing("test-opendata", 0, "host1")
+	p.TaskSyncing("test-opendata", 1, "host2")
+	p.TaskSyncing("test-opendata", 2, "host3")
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Transition to executing
+	p.TaskExecuting("test-opendata", 0)
+	p.TaskExecuting("test-opendata", 1)
+	p.TaskExecuting("test-opendata", 2)
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Complete in different order with different results
+	p.TaskCompleted("test-opendata", 1, true)  // index 1 passes
+	p.TaskCompleted("test-opendata", 2, false) // index 2 fails
+	p.TaskCompleted("test-opendata", 0, true)  // index 0 passes
+
+	time.Sleep(100 * time.Millisecond)
+
+	p.Stop()
+
+	output := buf.String()
+
+	// All three hosts should appear in output
+	assert.Contains(t, output, "[host1]")
+	assert.Contains(t, output, "[host2]")
+	assert.Contains(t, output, "[host3]")
+
+	// Should have both success and failure symbols
+	assert.Contains(t, output, SymbolSuccess)
+	assert.Contains(t, output, SymbolFail)
 }


### PR DESCRIPTION
## Summary
- Fix for duplicate task name collision in parallel execution
- Tasks with the same name (e.g., running `test-opendata` 3x for flaky test detection) now tracked separately by index

## Changes
- Add `Index` field to `TaskInfo` and `TaskResult` structs
- Create unique task IDs like `task#0`, `task#1` for state tracking
- Update `OutputManager` and `ParallelProgress` to track by task ID
- Log files now named `<taskname>_<index>.log` to prevent overwrites
- Add regression tests for duplicate task names

## Test plan
- [x] All existing tests pass
- [x] New regression tests verify duplicate name handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed handling of tasks with identical names in parallel execution—each task instance is now properly tracked, logged, and displayed separately.
  * Log files for duplicate-named tasks are now indexed (e.g., `task_0.log`, `task_1.log`) to prevent conflicts and data loss.
  * Task status and progress indicators now correctly distinguish between multiple instances of the same task.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->