### PR TITLE
feat: add viewport scrolling to monitor list view

### DIFF
--- a/internal/cli/monitor.go
+++ b/internal/cli/monitor.go
@@ -74,8 +74,8 @@ func monitorCommand(hostsFilter string, interval time.Duration) error {
 	// Create Bubble Tea model with host order for default sorting
 	model := monitor.NewModel(collector, interval, timeout, hostOrder)
 
-	// Run the TUI program
-	p := tea.NewProgram(model, tea.WithAltScreen())
+	// Run the TUI program with mouse support for scrolling
+	p := tea.NewProgram(model, tea.WithAltScreen(), tea.WithMouseCellMotion())
 	_, err = p.Run()
 
 	// Graceful shutdown: close all SSH connections


### PR DESCRIPTION
## Summary
Add viewport scrolling support to the monitor list view so content can scroll when there are more host cards than fit in the terminal.

## Changes
- Add listViewport for scrollable host cards
- Enable mouse wheel scrolling
- Support pgup/pgdn keyboard scrolling in list view
- Show scroll percentage indicator in footer when scrollable
- Remove 70-char card width cap so cards fill available space

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enabled full mouse support, including mouse wheel scrolling for navigation across views
  * Added scroll position indicators to the footer for better orientation
  * Improved list view rendering with dynamic scroll hints based on layout

* **Improvements**
  * Enhanced viewport content refresh when switching between detail and list views
  * Optimized scrolling behavior for smoother navigation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->