### PR TITLE
fix: measure actual SSH latency instead of metrics collection time

### DIFF
--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -37,7 +37,8 @@ const (
 	CriticalThreshold = 90.0
 )
 
-// Latency thresholds in milliseconds
+// Latency thresholds in milliseconds for actual SSH network latency.
+// These thresholds apply to the SSH probe round-trip time, not metrics collection time.
 const (
 	LatencyFast     = 50.0  // < 50ms is excellent (LAN/nearby)
 	LatencyNormal   = 200.0 // < 200ms is normal (VPN/regional)

--- a/internal/monitor/types.go
+++ b/internal/monitor/types.go
@@ -81,7 +81,7 @@ type HostResult struct {
 	Error        error         // Error if collection failed
 	LockInfo     *HostLockInfo // Lock status (nil if not checked or error)
 	ConnectedVia string        // SSH alias used to connect (e.g., "m4-tailscale")
-	Latency      time.Duration // Round-trip time for metrics collection
+	Latency      time.Duration // Actual SSH round-trip latency (from a lightweight probe)
 }
 
 // Duration returns how long the lock has been held.


### PR DESCRIPTION
## Summary
- Fix monitor displaying ~5000ms "degraded" latency when actual SSH latency is ~75-100ms
- Add dedicated SSH probe using lightweight `echo 1` command to measure real network latency
- Metrics collection time is no longer conflated with network latency

## Test plan
- [x] Unit tests pass
- [x] Linter passes
- [x] Build succeeds

Fixes #131

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Latency measurements now accurately reflect actual SSH network round-trip time via a dedicated probe, instead of metrics collection duration. This provides clearer visibility into network performance independent of collection execution time.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->