### PR TITLE
fix: respect project local_fallback config and add SSH agent docs

### DIFF
--- a/plugins/rr/skills/rr/SKILL.md
+++ b/plugins/rr/skills/rr/SKILL.md
@@ -145,6 +145,7 @@ Missing tools trigger actionable error messages. Tools with built-in installers 
 
 | Problem | Fix |
 |---------|-----|
+| SSH works but rr fails (macOS) | Add `AddKeysToAgent yes` to `~/.ssh/config`, then `ssh-add --apple-use-keychain <key>` |
 | SSH fails | Check `ssh <alias>` manually, verify `~/.ssh/config` |
 | "command not found" | Add `setup_commands` or check `require` config |
 | Sync slow | Add large dirs to `sync.exclude` |


### PR DESCRIPTION
## Summary

- Fix bug where `local_fallback: true` in project config was ignored (only global config was checked)
- Add local fallback when all hosts fail to connect (previously only triggered when all hosts were locked)
- Document SSH agent setup for macOS users, explaining why Go's SSH library needs keys in the agent

## Changes

**Bug fix (`internal/cli/loadbalance.go`):**
- Use `config.ResolveLocalFallback()` which properly checks project config first
- Add local fallback path when all connection attempts fail (not just when locked)

**Documentation:**
- `plugins/rr/commands/setup.md` - New Step 3 for SSH agent configuration
- `plugins/rr/skills/rr/SKILL.md` - Added troubleshooting entry
- `plugins/rr/skills/rr/troubleshooting.md` - Detailed section on macOS Keychain/SSH agent issue

## Test plan

- [x] `go test ./internal/cli/...` passes
- [x] `./scripts/e2e-test.sh` passes (with SSH keys loaded)
- [x] Verified local fallback works when hosts unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)