### PR TITLE
docs: add SSH agent troubleshooting for handshake failures

### DIFF
--- a/docs/ssh-setup.md
+++ b/docs/ssh-setup.md
@@ -124,9 +124,13 @@ Host devbox
     HostName 192.168.1.50
     User riley
     IdentityFile ~/.ssh/id_ed25519
+    AddKeysToAgent yes
+    UseKeychain yes
 ```
 
 Now `ssh devbox` connects to `riley@192.168.1.50` using your key.
+
+**Important:** The `AddKeysToAgent` and `UseKeychain` options (macOS) ensure your key is automatically loaded into the SSH agent. This is required for rr to work with passphrase-protected keys, since rr cannot prompt for passphrases interactively.
 
 The `IdentityFile` line tells SSH which private key to use. This is what makes the connection passwordless (assuming you've copied the public key to the remote with `ssh-copy-id`).
 
@@ -139,11 +143,15 @@ Host devbox-lan
     HostName 192.168.1.50
     User riley
     IdentityFile ~/.ssh/id_ed25519
+    AddKeysToAgent yes
+    UseKeychain yes
 
 Host devbox-tailscale
     HostName devbox.tailnet-name.ts.net
     User riley
     IdentityFile ~/.ssh/id_ed25519
+    AddKeysToAgent yes
+    UseKeychain yes
 ```
 
 Then in your global config (`~/.rr/config.yaml`), list both and rr will use whichever one is reachable:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -128,6 +128,33 @@ Or per-command:
 rr run --probe-timeout 10s "make test"
 ```
 
+### "handshake failed" but ssh command works
+
+**Symptom:** `rr monitor` or `rr doctor` shows "handshake failed", but `ssh user@host` works fine from the terminal.
+
+**Cause:** Your SSH key is passphrase-protected and not loaded in the agent. The `ssh` command can prompt for the passphrase or use macOS Keychain automatically, but rr's Go SSH library cannot prompt interactively.
+
+**Fix:**
+
+1. Add your key to the SSH agent:
+   ```bash
+   ssh-add ~/.ssh/id_rsa  # or your key file
+   ```
+
+2. Verify the key is loaded:
+   ```bash
+   ssh-add -l
+   ```
+
+3. To persist across reboots (macOS), add to your `~/.ssh/config`:
+   ```
+   Host your-host
+       AddKeysToAgent yes
+       UseKeychain yes
+   ```
+
+This ensures the key is automatically added to the agent and the passphrase is stored in Keychain.
+
 ### "SSH agent not running"
 
 **Symptom:** `rr doctor` shows "SSH_AUTH_SOCK not set"

--- a/plugins/rr/commands/setup.md
+++ b/plugins/rr/commands/setup.md
@@ -55,6 +55,20 @@ If SSH fails, debug systematically:
     - Password prompt: needs key-based auth
     - Host not found: add to `~/.ssh/config`
     - Timeout: host unreachable, try alternative address
+    - **"handshake failed" but ssh works**: Key not in agent. Run `ssh-add ~/.ssh/id_rsa`
+
+**Important for passphrase-protected keys:** Ensure your SSH config includes `AddKeysToAgent yes` and `UseKeychain yes` (macOS) so keys are automatically loaded:
+
+```
+Host your-host
+    HostName 192.168.x.x
+    User youruser
+    IdentityFile ~/.ssh/id_rsa
+    AddKeysToAgent yes
+    UseKeychain yes
+```
+
+This prevents "handshake failed" errors where `ssh` works but rr cannot connect.
 
 ## Step 4: Test Execution
 
@@ -140,6 +154,7 @@ rr run "make test"  # or appropriate command for the project
 | Problem             | Fix                                                         |
 | ------------------- | ----------------------------------------------------------- |
 | SSH fails           | Check `ssh <alias>` manually, verify `~/.ssh/config`        |
+| "handshake failed"  | Key not in agent: `ssh-add`, add `AddKeysToAgent yes` to SSH config |
 | "command not found" | Add `shell: "zsh -l -c"` or `setup_commands` to host config |
 | Sync slow           | Add large dirs to `sync.exclude`                            |
 | Lock stuck          | `rr unlock`                                                 |

--- a/plugins/rr/skills/rr/SKILL.md
+++ b/plugins/rr/skills/rr/SKILL.md
@@ -256,6 +256,7 @@ Missing tools trigger actionable error messages. Tools with built-in installers 
 | Problem | Fix |
 |---------|-----|
 | SSH fails | Check `ssh <alias>` manually, verify `~/.ssh/config` |
+| "handshake failed" but ssh works | Key not in agent: `ssh-add ~/.ssh/id_rsa`, add `AddKeysToAgent yes` to SSH config |
 | "command not found" | Add `setup_commands` or check `require` config |
 | Sync slow | Add large dirs to `sync.exclude` |
 | Lock stuck | `rr unlock` |


### PR DESCRIPTION
## Summary
- Add 'handshake failed but ssh works' section to troubleshooting.md
- Update ssh-setup.md to recommend AddKeysToAgent/UseKeychain as default
- Update SKILL.md and setup.md troubleshooting tables

This addresses a common issue where `ssh user@host` works but rr fails with "handshake failed" because the SSH key is passphrase-protected and not loaded in the agent.