### PR TITLE
feat(monitor): add GPU monitoring for Apple Silicon and NVIDIA

### DIFF
--- a/internal/monitor/command.go
+++ b/internal/monitor/command.go
@@ -46,9 +46,10 @@ func buildLinuxCommand() string {
 // 0. top output - CPU usage and load averages
 // 1. vm_stat + sysctl hw.memsize - Memory statistics with total memory
 // 2. netstat output - Network interface statistics
-// 3. ps aux - Process list sorted by CPU (top 16 including header)
+// 3. ioreg GPU output - Apple Silicon GPU metrics (optional, fails silently)
+// 4. ps aux - Process list sorted by CPU (top 16 including header)
 func buildDarwinCommand() string {
-	return `top -l 1 -n 0 2>/dev/null; echo "---"; vm_stat; sysctl hw.memsize 2>/dev/null; echo "---"; netstat -ib; echo "---"; ps aux -r 2>/dev/null | head -16`
+	return `top -l 1 -n 0 2>/dev/null; echo "---"; vm_stat; sysctl hw.memsize 2>/dev/null; echo "---"; netstat -ib; echo "---"; ioreg -r -c AGXAccelerator 2>/dev/null | grep -E '"(model|gpu-core-count|PerformanceStatistics)"' || true; echo "---"; ps aux -r 2>/dev/null | head -16`
 }
 
 // PlatformDetectCommand returns the command to detect the platform type.

--- a/internal/monitor/command_test.go
+++ b/internal/monitor/command_test.go
@@ -120,9 +120,9 @@ func TestBuildLinuxCommand_SectionCount(t *testing.T) {
 func TestBuildDarwinCommand_SectionCount(t *testing.T) {
 	cmd := BuildMetricsCommand(PlatformDarwin)
 
-	// Darwin command should have 3 separators (4 sections)
+	// Darwin command should have 4 separators (5 sections: top, vm_stat, netstat, ioreg GPU, ps)
 	separatorCount := strings.Count(cmd, `echo "---"`)
-	assert.Equal(t, 3, separatorCount, "Darwin command should have 3 separators for 4 sections")
+	assert.Equal(t, 4, separatorCount, "Darwin command should have 4 separators for 5 sections")
 }
 
 func TestBuildMetricsCommand_GracefulGPUFailure(t *testing.T) {

--- a/internal/monitor/styles.go
+++ b/internal/monitor/styles.go
@@ -45,6 +45,12 @@ const (
 	LatencyDegraded = 500.0 // >= 500ms is degraded (slow/intercontinental)
 )
 
+// GPU temperature thresholds in Celsius.
+const (
+	GPUTempWarning  = 70 // >= 70C is warm
+	GPUTempCritical = 80 // >= 80C is hot
+)
+
 // Base styles for the dashboard
 var (
 	// Container styles
@@ -226,6 +232,24 @@ func LatencyQualityText(ms float64) string {
 // LatencyStyle returns a style with the appropriate foreground color for latency.
 func LatencyStyle(ms float64) lipgloss.Style {
 	return lipgloss.NewStyle().Foreground(LatencyColor(ms))
+}
+
+// GPUTempColor returns the appropriate color for a GPU temperature in Celsius.
+// Cyan < 70C (normal), Purple 70-79C (warm), Pink >= 80C (hot).
+func GPUTempColor(temp int) lipgloss.Color {
+	switch {
+	case temp >= GPUTempCritical:
+		return ColorCritical
+	case temp >= GPUTempWarning:
+		return ColorWarning
+	default:
+		return ColorHealthy
+	}
+}
+
+// GPUTempStyle returns a style with the appropriate foreground color for GPU temperature.
+func GPUTempStyle(temp int) lipgloss.Style {
+	return lipgloss.NewStyle().Foreground(GPUTempColor(temp))
 }
 
 // ProgressBar renders a progress bar with the given width and percentage.


### PR DESCRIPTION
## Summary
- Add GPU section to dashboard cards (standard, compact, minimal modes)
- Display GPU utilization percentage with temperature in cards
- Reorder card layout: CPU, GPU, LAT, RAM, TOP, NET
- Add Apple Silicon GPU support via ioreg AGXAccelerator parsing
- Add GPU temperature color thresholds (70C warning, 80C critical)
- Reorganize detail view: CPU|GPU side-by-side, Processes|Latency side-by-side
- Add 8-row braille sparkline graphs for GPU in detail view

## Test plan
- [x] Unit tests pass (`rr verify`)
- [x] Lint clean
- [ ] Manual testing with `rr monitor` on Apple Silicon hosts

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Apple Silicon GPU monitoring on macOS: real-time metrics for utilization, memory usage, and temperature
  * GPU displayed alongside CPU metrics with history graphs
  * Temperature-based color indicators for GPU health status

* **Improvements**
  * Optimized layout with side-by-side CPU/GPU display
  * Process list limited to 5 entries for better clarity
  * Memory section now displays "Used / Total" format
  * Enhanced network and latency visualization

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->