### PR TITLE
fix(test): resolve data race in TestOutputManager_ProgressMode

### DIFF
--- a/internal/parallel/output_test.go
+++ b/internal/parallel/output_test.go
@@ -223,13 +223,6 @@ func TestOutputManager_ProgressMode(t *testing.T) {
 	mgr.SetWriter(&buf)
 
 	mgr.TaskStarted("test", 0, "dev")
-
-	output := buf.String()
-	assert.Contains(t, output, "test")
-	assert.Contains(t, output, "[dev]")
-
-	buf.Reset()
-
 	mgr.TaskCompleted(TaskResult{
 		TaskName:  "test",
 		TaskIndex: 0,
@@ -237,8 +230,12 @@ func TestOutputManager_ProgressMode(t *testing.T) {
 		ExitCode:  0,
 	})
 
-	output = buf.String()
+	// Stop the animation goroutine before reading the buffer to avoid data race
+	mgr.Close()
+
+	output := buf.String()
 	assert.Contains(t, output, "test")
+	assert.Contains(t, output, "[dev]")
 }
 
 func TestOutputManager_Close(t *testing.T) {


### PR DESCRIPTION
## Summary
- Stop animation goroutine before reading buffer in progress mode test
- Fixes race between test reading `buf.String()` and background animation writing

## Test plan
- [x] `go test -race ./internal/parallel/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Fixed a data race condition in progress mode output handling tests to ensure reliable test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->