### PR TITLE
feat(parallel): add setup phase that runs once per host before subtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Parallel task setup phase** - New `setup` field for parallel tasks runs a command once per host before any subtasks execute. Avoids redundant work when multiple subtasks on the same host need shared setup (dependency installation, database migrations, etc.). Setup failure aborts all subtasks on that host. Works with both remote and local execution.
+
 ## [0.16.0] - 2026-01-24
 
 ### Added

--- a/internal/cli/parallel.go
+++ b/internal/cli/parallel.go
@@ -103,7 +103,7 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 
 	// If dry run, just show the plan
 	if opts.DryRun {
-		renderDryRunPlan(opts.TaskName, tasks, hosts)
+		renderDryRunPlan(opts.TaskName, tasks, hosts, task.Setup)
 		return 0, nil
 	}
 
@@ -116,6 +116,7 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 		FailFast:    task.FailFast,
 		OutputMode:  outputMode,
 		SaveLogs:    !opts.NoLogs,
+		Setup:       task.Setup,
 	}
 
 	// Apply CLI overrides
@@ -295,8 +296,13 @@ func filterHostsByTag(hosts map[string]config.Host, hostOrder []string, tag stri
 }
 
 // renderDryRunPlan shows what would be executed without actually running.
-func renderDryRunPlan(taskName string, tasks []parallel.TaskInfo, hosts map[string]config.Host) {
+func renderDryRunPlan(taskName string, tasks []parallel.TaskInfo, hosts map[string]config.Host, setup string) {
 	fmt.Printf("Dry run for parallel task: %s\n\n", taskName)
+
+	if setup != "" {
+		fmt.Println("Setup (runs once per host):")
+		fmt.Printf("  $ %s\n\n", setup)
+	}
 
 	fmt.Println("Tasks to execute:")
 	for i, task := range tasks {
@@ -386,6 +392,9 @@ func FormatParallelTaskHelp(task *config.TaskConfig, cfg *config.Config) string 
 		help += "\n"
 	}
 
+	if task.Setup != "" {
+		help += fmt.Sprintf("\nSetup (once per host): %s\n", task.Setup)
+	}
 	if task.FailFast {
 		help += "\nStops on first failure (fail_fast: true)\n"
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -154,6 +154,12 @@ type TaskConfig struct {
 	// When set, this task becomes a parallel orchestrator and Run/Steps are ignored.
 	Parallel []string `yaml:"parallel" mapstructure:"parallel"`
 
+	// Setup is a command that runs once per host before any subtasks execute on that host.
+	// Only applies to parallel tasks. Useful for dependency installation, database migrations,
+	// or other one-time setup that shouldn't be repeated for each subtask.
+	// Setup failure aborts all subtasks on that host.
+	Setup string `yaml:"setup,omitempty" mapstructure:"setup"`
+
 	// FailFast stops parallel/dependency execution on first failure when true.
 	FailFast bool `yaml:"fail_fast" mapstructure:"fail_fast"`
 

--- a/internal/parallel/types.go
+++ b/internal/parallel/types.go
@@ -27,6 +27,7 @@ type Config struct {
 	OutputMode  OutputMode    // How to display output
 	SaveLogs    bool          // Write output to log files
 	LogDir      string        // Directory for log files
+	Setup       string        // Command to run once per host before subtasks
 }
 
 // DefaultConfig returns a Config with sensible defaults.

--- a/plugins/rr/skills/rr/SKILL.md
+++ b/plugins/rr/skills/rr/SKILL.md
@@ -131,6 +131,22 @@ hosts:
 
 Run with: `rr test-all`, `rr quick-check`
 
+#### Setup Phase (Once Per Host)
+
+Avoid redundant setup work (dependency sync, migrations) when multiple subtasks run on the same host:
+
+```yaml
+tasks:
+  test-all:
+    setup: pip install -r requirements.txt   # Runs once per host
+    parallel:
+      - test-unit
+      - test-integration
+      - test-e2e
+```
+
+Setup runs exactly once per host before any subtasks execute. If a host runs 3 subtasks, setup runs once (not 3 times).
+
 #### Parallel Task Flags
 
 | Flag | Purpose |


### PR DESCRIPTION
## Summary

- Adds `setup` field to parallel tasks that executes once per host before any subtasks
- Setup runs after file sync but before the first subtask on each host
- Setup failures properly abort all subsequent tasks on that host
- Works for both remote (SSH) and local execution paths

Closes #147

## Example

```yaml
tasks:
  test-all:
    setup: pip install -r requirements.txt   # Runs once per host
    parallel:
      - test-unit
      - test-integration
      - test-e2e
```

## Changes

- `internal/config/types.go` - Added `Setup` field to `TaskConfig`
- `internal/parallel/types.go` - Added `Setup` field to execution `Config`
- `internal/parallel/orchestrator.go` - Added setup tracking with error propagation
- `internal/parallel/worker.go` - Implemented `ensureSetup()` for both hostWorker and localWorker
- `internal/cli/parallel.go` - Pass setup config, show in dry-run and help
- Updated docs and skills folder

## Test plan

- [x] Unit tests for setup execution (success and failure cases)
- [x] Tests verify setup failure aborts all tasks on that host
- [x] Config parsing tests for new `setup` field
- [x] `rr verify-all` passes
- [x] Pre-push hooks pass (lint, test, coverage)


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setup phase for parallel tasks that runs once per host before subtasks execute, preventing redundant per-host setup overhead.
  * Setup failures now abort all subsequent subtasks on the affected host.

* **Documentation**
  * Added comprehensive documentation describing the new per-host setup phase, including behavior and compatibility with local and remote execution.

* **Tests**
  * Added tests validating setup execution, single-run behavior per host, and failure handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->