### PR TITLE
feat(parallel): support nested parallel tasks with automatic flattening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nested parallel tasks** - Parallel tasks can now reference other parallel tasks. When `rr` encounters a nested parallel reference, it flattens the task tree before execution. This makes maintaining large parallel task groups much easier. For example, `test: {parallel: [test-opendata, test-backend]}` where `test-opendata` is itself a parallel task with 3 subtasks will expand to all 4+ tasks running in parallel. Cycle detection prevents infinite recursion. `--dry-run` shows the expanded task list. Fixes #145.
+
 - **Parallel task setup phase** - New `setup` field for parallel tasks runs a command once per host before any subtasks execute. Avoids redundant work when multiple subtasks on the same host need shared setup (dependency installation, database migrations, etc.). Setup failure aborts all subtasks on that host. Works with both remote and local execution.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -210,6 +210,21 @@ Parallel Execution Summary
 
 **Why this is powerful:** A 10-minute test suite split across 4 hosts finishes in ~2.5 minutes. For agentic coding workflows where AI agents constantly run tests to verify their work, this means faster feedback loops and less waiting. Multiple agents or features being developed simultaneously get distributed across your machine pool automatically.
 
+**Nested parallel tasks:** Parallel tasks can reference other parallel tasks. `rr` flattens the hierarchy automatically:
+
+```yaml
+tasks:
+    test-opendata:
+        parallel: [opendata-1, opendata-2, opendata-3]
+    test-backend:
+        parallel: [backend-1, backend-2, backend-3]
+    # References both parallel tasks - expands to 7 tasks total
+    test:
+        parallel: [test-opendata, test-backend, frontend]
+```
+
+Run `rr test-opendata` for just the opendata splits, or `rr test` for everything. Add splits to `test-opendata` and `test` automatically includes them.
+
 **Output modes:**
 
 ```bash


### PR DESCRIPTION
## Summary

- Allow parallel tasks to reference other parallel tasks
- Automatically flatten nested parallel references at execution time
- Detect and prevent circular references (A -> B -> A)
- Deduplicate diamond dependencies (shared task runs once)

## Example

```yaml
tasks:
  test-opendata:
    parallel: [opendata-1, opendata-2, opendata-3]
  test-backend:
    parallel: [backend-1, backend-2, backend-3]
  # References parallel tasks - expands to 7 tasks
  test:
    parallel: [test-opendata, test-backend, frontend]
```

Running `rr test` expands to: `opendata-1`, `opendata-2`, `opendata-3`, `backend-1`, `backend-2`, `backend-3`, `frontend`

## Benefits

- Run `rr test-opendata` for just opendata splits
- Run `rr test` for everything
- Add a 4th split to `test-opendata` and `test` automatically includes it
- No manual flattening or repetition required
- `--dry-run` shows the expanded task list

## Test plan

- [x] Unit tests for `FlattenParallelTasks` function
- [x] Unit tests for cycle detection
- [x] Unit tests for diamond dependency deduplication
- [x] Validation tests for nested parallel refs
- [x] Linter passes
- [x] All existing tests pass

Fixes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parallel tasks can now reference other parallel tasks, with automatic flattening and deduplication.
  * Enhanced dry-run output displays expanded task hierarchies with total execution count.
  * Added validation to detect circular references in parallel task configurations.

* **Documentation**
  * Added comprehensive sections on nested parallel task configuration, usage patterns, and CLI flags for parallel execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->