### PR TITLE
chore: bump plugin version to 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -6,14 +6,14 @@
   },
   "metadata": {
     "description": "Claude Code plugin for the rr CLI - sync code and run commands on remote machines",
-    "version": "1.2.0"
+    "version": "1.3.0"
   },
   "plugins": [
     {
       "name": "rr",
       "source": "./plugins/rr/",
       "description": "Teaches Claude to use the rr CLI for syncing code and running commands on remote machines",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Riley Hilliard",
         "url": "https://github.com/rileyhilliard"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "rr",
   "description": "rr CLI skill - sync code and run commands on remote machines",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "author": {
     "name": "Riley Hilliard"
   },


### PR DESCRIPTION
Bump plugin version for v0.17.0 release with nested parallel tasks.