### PR TITLE
fix: resolve orchestrator deadlock on parallel task completion

### DIFF
--- a/internal/parallel/orchestrator_test.go
+++ b/internal/parallel/orchestrator_test.go
@@ -867,9 +867,9 @@ func TestOrchestrator_RemotePath_CompletesWithoutDeadlock(t *testing.T) {
 			require.NoError(t, ctx.Err(),
 				"context timed out — likely deadlock in orchestrator shutdown")
 
-			// All returned results should be failures (hosts are unreachable)
-			assert.Greater(t, len(result.TaskResults), 0,
-				"should have at least one task result")
+			// Every task should produce a result (hosts are unreachable, so all fail)
+			require.Equal(t, len(tt.tasks), len(result.TaskResults),
+				"expected one result per task")
 			for _, tr := range result.TaskResults {
 				assert.False(t, tr.Success(), "task %s should have failed", tr.TaskName)
 			}


### PR DESCRIPTION
Closes #177

## Summary

Parallel tasks hang indefinitely after all tasks complete. The reported symptom is correct, but the root cause is different from what the issue describes.

## Root cause analysis

#177 attributes the hang to a signal handler goroutine leak (`signal.Notify` without `signal.Stop`). That's not it. A goroutine blocked on `<-sigChan` can't prevent Go from exiting, because Go terminates all goroutines when `main()` returns. The `workflow.go` cleanup pattern is good hygiene but isn't what keeps the process alive.

The actual problem is a channel deadlock in the orchestrator's shutdown sequence (`internal/parallel/orchestrator.go`). After all tasks finish:

1. **Workers** complete their tasks, loop back, block reading from `taskQueue`
2. **Dispatcher** blocks on `for task := range requeueChan`, waiting for requeued tasks that will never come
3. **Cleanup goroutine** blocks on `wg.Wait()`, waiting for workers to exit

Circular dependency: workers wait on `taskQueue` (closed by dispatcher) while the dispatcher waits on `requeueChan` (closed only after workers exit). Nobody can make progress.

## Reproduction

Built the binary, ran `rr quick-check` (parallel: [vet, lint]). Process hung after both tasks completed. Used `kill -SIGABRT` to get goroutine dumps confirming workers stuck in `[select]` at the `taskQueue` read and the dispatcher stuck on `requeueChan`.

## Fix

Added an `allDone` signal channel that gets closed (via `sync.Once`) when all expected results are collected. The dispatcher now selects on `allDone` alongside `requeueChan` and `ctx.Done()`, so it can exit once everything's accounted for. This closes `taskQueue`, which unblocks workers, and the whole shutdown chain completes.

## Changes

- Add `allDone` channel to break the circular shutdown dependency in `orchestrator.Run()`
- Guard `close(allDone)` with `sync.Once` to prevent double-close if a future code path produces unexpected extra results
- Dispatcher selects on `allDone` in both the initial dispatch loop and the post-dispatch requeue loop
- Track `expectedResults` and `collected` count in the result-gathering loop

## Testing

- Added `TestOrchestrator_RemotePath_CompletesWithoutDeadlock` regression test with 4 scenarios (single/multi task, single/multi host, more tasks than hosts)
- Test uses a 5-second context timeout as a deadlock detector
- All existing tests pass, race detector clean

## Notes

The signal handler cleanup the reporter flagged (`signal.Stop`/`close` in `parallel.go`, `run.go`, `task.go`) is a real gap worth fixing for hygiene, but it's a separate concern. It doesn't cause the hang and should be addressed in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown coordination for parallel task orchestration to avoid deadlocks when remote hosts are unreachable; unconsumed tasks are now handled and failures are reported reliably.

* **Tests**
  * Added a regression test to verify parallel execution completes without deadlock when remote hosts cannot be reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->