### PR TITLE
feat: add SSH ProxyCommand support and rsync config passthrough

### DIFF
--- a/internal/host/probe_test.go
+++ b/internal/host/probe_test.go
@@ -30,6 +30,7 @@ func TestCategorizeProbeError_Refused(t *testing.T) {
 	err := categorizeProbeError("test-host", errors.New("connection refused"))
 	if err == nil {
 		t.Fatal("categorizeProbeError returned nil")
+		return
 	}
 
 	if err.Reason != ProbeFailRefused {
@@ -82,6 +83,7 @@ func TestCategorizeProbeError_HostKey(t *testing.T) {
 	err := categorizeProbeError("test-host", errors.New("host key verification failed"))
 	if err == nil {
 		t.Fatal("categorizeProbeError returned nil")
+		return
 	}
 
 	if err.Reason != ProbeFailHostKey {
@@ -93,6 +95,7 @@ func TestCategorizeProbeError_Unknown(t *testing.T) {
 	err := categorizeProbeError("test-host", errors.New("some random error"))
 	if err == nil {
 		t.Fatal("categorizeProbeError returned nil")
+		return
 	}
 
 	if err.Reason != ProbeFailUnknown {

--- a/internal/host/selector_test.go
+++ b/internal/host/selector_test.go
@@ -158,6 +158,7 @@ func TestNewSelector(t *testing.T) {
 	selector := NewSelector(hosts)
 	if selector == nil {
 		t.Fatal("NewSelector returned nil")
+		return
 	}
 
 	if selector.timeout != DefaultProbeTimeout {

--- a/internal/sync/pull.go
+++ b/internal/sync/pull.go
@@ -151,13 +151,9 @@ func BuildPullArgs(conn *host.Connection, patterns []string, localDest string, e
 		"-az", // archive mode, compress
 	}
 
-	// Use SSH ControlMaster to reuse existing connections
-	sshCmd := fmt.Sprintf("ssh -o ControlMaster=auto -o ControlPath=%s/%%h-%%p -o ControlPersist=60 -o BatchMode=yes",
-		controlSocketDir)
-	if SSHConfigFile != "" {
-		sshCmd = fmt.Sprintf("%s -F %q", sshCmd, SSHConfigFile)
-	}
-	args = append(args, "-e", sshCmd)
+	// Use SSH with ControlMaster for connection reuse and user's SSH config
+	// for ProxyCommand, IdentityFile, and other host-specific settings.
+	args = append(args, "-e", buildSSHCmd())
 
 	// Add progress info flag for parsing
 	args = append(args, "--info=progress2")

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -25,6 +25,27 @@ var controlSocketDir = filepath.Join(os.TempDir(), "rr-ssh")
 // host configurations.
 var SSHConfigFile string
 
+// buildSSHCmd returns the SSH command string for rsync's -e flag.
+// It includes ControlMaster for connection reuse and loads the user's SSH config
+// so rsync inherits ProxyCommand, IdentityFile, and other host-specific settings.
+func buildSSHCmd() string {
+	cmd := fmt.Sprintf("ssh -o ControlMaster=auto -o ControlPath=%s/%%h-%%p -o ControlPersist=60 -o BatchMode=yes",
+		controlSocketDir)
+	configFile := SSHConfigFile
+	if configFile == "" {
+		if home, err := os.UserHomeDir(); err == nil {
+			candidate := filepath.Join(home, ".ssh", "config")
+			if _, err := os.Stat(candidate); err == nil {
+				configFile = candidate
+			}
+		}
+	}
+	if configFile != "" {
+		cmd = fmt.Sprintf("%s -F %q", cmd, configFile)
+	}
+	return cmd
+}
+
 // Sync transfers files from localDir to the remote host using rsync.
 // Progress output is streamed to the progress writer if provided.
 //
@@ -136,20 +157,9 @@ func BuildArgs(conn *host.Connection, localDir string, cfg config.SyncConfig) ([
 		"--force",  // force deletion of non-empty dirs
 	}
 
-	// Use SSH ControlMaster to reuse existing connections.
-	// This avoids a second SSH handshake when we already have an active connection.
-	// ControlPath uses a hash of the host to create unique socket files.
-	// ControlMaster=auto: reuse existing socket or create new one if needed.
-	// ControlPersist=60: keep the socket alive for 60s after last use.
-	// BatchMode=yes: prevent SSH from prompting for input (passwords, host keys, etc.)
-	//   which would cause rsync to hang since there's no terminal attached.
-	sshCmd := fmt.Sprintf("ssh -o ControlMaster=auto -o ControlPath=%s/%%h-%%p -o ControlPersist=60 -o BatchMode=yes",
-		controlSocketDir)
-	// Support custom SSH config file (useful for testing)
-	if SSHConfigFile != "" {
-		sshCmd = fmt.Sprintf("%s -F %q", sshCmd, SSHConfigFile)
-	}
-	args = append(args, "-e", sshCmd)
+	// Use SSH with ControlMaster for connection reuse and user's SSH config
+	// for ProxyCommand, IdentityFile, and other host-specific settings.
+	args = append(args, "-e", buildSSHCmd())
 
 	// Add progress info flag for parsing
 	args = append(args, "--info=progress2")

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -1,7 +1,9 @@
 package sync
 
 import (
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -282,7 +284,7 @@ func TestBuildArgs_SSHConfigFile(t *testing.T) {
 		Host:  config.Host{Dir: "~/projects/app"},
 	}
 
-	t.Run("without custom config", func(t *testing.T) {
+	t.Run("without custom config uses default ssh config if present", func(t *testing.T) {
 		SSHConfigFile = ""
 		args, err := BuildArgs(conn, "/home/user/app", config.SyncConfig{})
 		require.NoError(t, err)
@@ -295,7 +297,17 @@ func TestBuildArgs_SSHConfigFile(t *testing.T) {
 			}
 		}
 
-		assert.NotContains(t, sshCmd, "-F ", "should not include -F flag when SSHConfigFile is empty")
+		// When ~/.ssh/config exists, -F should point to it so rsync inherits
+		// ProxyCommand, IdentityFile, and other host-specific SSH settings.
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		defaultConfig := filepath.Join(home, ".ssh", "config")
+		if _, err := os.Stat(defaultConfig); err == nil {
+			assert.Contains(t, sshCmd, "-F", "should include -F when ~/.ssh/config exists")
+			assert.Contains(t, sshCmd, defaultConfig)
+		} else {
+			assert.NotContains(t, sshCmd, "-F", "should not include -F when ~/.ssh/config doesn't exist")
+		}
 	})
 
 	t.Run("with custom config", func(t *testing.T) {
@@ -330,6 +342,40 @@ func TestBuildArgs_SSHConfigFile(t *testing.T) {
 
 		assert.Contains(t, sshCmd, `-F "/tmp/my ssh config/config"`,
 			"should properly quote paths with spaces")
+	})
+}
+
+func TestBuildSSHCmd(t *testing.T) {
+	origConfigFile := SSHConfigFile
+	defer func() { SSHConfigFile = origConfigFile }()
+
+	t.Run("includes ControlMaster options", func(t *testing.T) {
+		SSHConfigFile = ""
+		cmd := buildSSHCmd()
+		assert.Contains(t, cmd, "ControlMaster=auto")
+		assert.Contains(t, cmd, "ControlPath=")
+		assert.Contains(t, cmd, "ControlPersist=60")
+		assert.Contains(t, cmd, "BatchMode=yes")
+	})
+
+	t.Run("custom config file", func(t *testing.T) {
+		SSHConfigFile = "/tmp/custom-ssh-config"
+		cmd := buildSSHCmd()
+		assert.Contains(t, cmd, `-F "/tmp/custom-ssh-config"`)
+	})
+
+	t.Run("default config when file exists", func(t *testing.T) {
+		SSHConfigFile = ""
+		home, err := os.UserHomeDir()
+		require.NoError(t, err)
+		defaultConfig := filepath.Join(home, ".ssh", "config")
+		if _, err := os.Stat(defaultConfig); err == nil {
+			cmd := buildSSHCmd()
+			assert.Contains(t, cmd, "-F")
+			assert.Contains(t, cmd, defaultConfig)
+		} else {
+			t.Skip("~/.ssh/config does not exist")
+		}
 	})
 }
 

--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -11,6 +11,7 @@ import (
 	"runtime"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/kevinburke/ssh_config"
@@ -91,13 +92,24 @@ func Dial(host string, timeout time.Duration) (*Client, error) {
 	// For direct TCP, net.DialTimeout already enforces the timeout on the TCP connection.
 	// For proxy connections, we need our own timeout since the proxy may connect but the
 	// SSH handshake could stall (e.g., hung bastion host).
+	var proxyTimedOut atomic.Bool
 	if settings.proxyCommand != "" {
-		timer := time.AfterFunc(timeout, func() { conn.Close() })
+		timer := time.AfterFunc(timeout, func() {
+			proxyTimedOut.Store(true)
+			conn.Close()
+		})
 		defer timer.Stop()
 	}
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, address, config)
 	if err != nil {
 		conn.Close()
+
+		// If the proxy handshake timed out, give a specific error
+		if proxyTimedOut.Load() {
+			return nil, errors.WrapWithCode(err, errors.ErrSSH,
+				fmt.Sprintf("SSH handshake via ProxyCommand timed out for '%s'", host),
+				"The proxy connected but the SSH handshake didn't complete. Check the remote host is running SSH.")
+		}
 
 		// Check for host key mismatch error (provides detailed suggestion)
 		var hostKeyErr *HostKeyMismatchError

--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -68,16 +68,33 @@ func Dial(host string, timeout time.Duration) (*Client, error) {
 			"Check your keys are loaded: ssh-add -l")
 	}
 
-	// Dial with timeout
+	// Dial with timeout, using ProxyCommand if configured
 	address := settings.address()
-	conn, err := net.DialTimeout("tcp", address, timeout)
-	if err != nil {
-		return nil, errors.WrapWithCode(err, errors.ErrSSH,
-			fmt.Sprintf("Can't reach '%s' at %s", host, address),
-			suggestionForDialError(err))
+	var conn net.Conn
+	if settings.proxyCommand != "" {
+		conn, err = dialViaProxy(settings.proxyCommand, host, settings)
+		if err != nil {
+			return nil, errors.WrapWithCode(err, errors.ErrSSH,
+				fmt.Sprintf("ProxyCommand failed for '%s'", host),
+				"Check your ProxyCommand in ~/.ssh/config and verify it works: ssh "+host)
+		}
+	} else {
+		conn, err = net.DialTimeout("tcp", address, timeout)
+		if err != nil {
+			return nil, errors.WrapWithCode(err, errors.ErrSSH,
+				fmt.Sprintf("Can't reach '%s' at %s", host, address),
+				suggestionForDialError(err))
+		}
 	}
 
-	// SSH handshake
+	// SSH handshake with timeout for proxy connections.
+	// For direct TCP, net.DialTimeout already enforces the timeout on the TCP connection.
+	// For proxy connections, we need our own timeout since the proxy may connect but the
+	// SSH handshake could stall (e.g., hung bastion host).
+	if settings.proxyCommand != "" {
+		timer := time.AfterFunc(timeout, func() { conn.Close() })
+		defer timer.Stop()
+	}
 	sshConn, chans, reqs, err := ssh.NewClientConn(conn, address, config)
 	if err != nil {
 		conn.Close()
@@ -150,6 +167,7 @@ type sshSettings struct {
 	port          string
 	user          string
 	identityFile  string
+	proxyCommand  string   // ProxyCommand from SSH config (if any)
 	encryptedKeys []string // Keys that exist but are encrypted
 }
 
@@ -242,6 +260,21 @@ func resolveSSHSettings(host string) *sshSettings {
 	if identity, _ := cfg.Get(host, "IdentityFile"); identity != "" {
 		settings.identityFile = expandPath(identity)
 		hostFound = true
+	}
+
+	// Get ProxyCommand
+	if proxyCmd, _ := cfg.Get(host, "ProxyCommand"); proxyCmd != "" {
+		settings.proxyCommand = proxyCmd
+		hostFound = true
+	}
+
+	// Warn about ProxyJump (not yet supported, but detectable)
+	if settings.proxyCommand == "" {
+		if proxyJump, _ := cfg.Get(host, "ProxyJump"); proxyJump != "" {
+			emitWarning(fmt.Sprintf(
+				"Host '%s' uses ProxyJump which is not yet supported. "+
+					"Convert to ProxyCommand: ProxyCommand ssh -W %%h:%%p %s", host, proxyJump))
+		}
 	}
 
 	// Only warn about Match block if host wasn't found - it might be defined after the Match

--- a/pkg/sshutil/proxy.go
+++ b/pkg/sshutil/proxy.go
@@ -1,3 +1,6 @@
+// NOTE: This file uses Unix-specific syscalls (Setpgid, Kill with negative PID).
+// If Windows support is ever needed, this file needs a //go:build !windows constraint.
+
 package sshutil
 
 import (
@@ -73,13 +76,13 @@ func (c *proxyConn) Close() error {
 
 		// Wait for process to exit with a grace period
 		select {
-		case <-c.waitCh:
-			// Process exited
+		case err := <-c.waitCh:
+			c.closeErr = err
 		case <-time.After(2 * time.Second):
 			// Force kill the process group
 			if c.cmd.Process != nil {
 				_ = syscall.Kill(-c.cmd.Process.Pid, syscall.SIGKILL)
-				<-c.waitCh
+				c.closeErr = <-c.waitCh
 			}
 		}
 
@@ -88,8 +91,14 @@ func (c *proxyConn) Close() error {
 	return c.closeErr
 }
 
-func (c *proxyConn) LocalAddr() net.Addr                { return proxyAddr{addr: "proxy"} }
-func (c *proxyConn) RemoteAddr() net.Addr               { return proxyAddr{addr: c.addr} }
+func (c *proxyConn) LocalAddr() net.Addr  { return proxyAddr{addr: "proxy"} }
+func (c *proxyConn) RemoteAddr() net.Addr { return proxyAddr{addr: c.addr} }
+
+// Deadline methods are no-ops. Verified in golang.org/x/crypto@v0.48.0 that
+// ssh.NewClientConn does NOT call SetDeadline on the net.Conn. The SSH library's
+// own test mocks (server_test.go, recording_test.go) use no-op deadlines.
+// Handshake timeout for proxy connections is enforced externally via time.AfterFunc
+// in Dial(), which closes the conn if the handshake stalls.
 func (c *proxyConn) SetDeadline(_ time.Time) error      { return nil }
 func (c *proxyConn) SetReadDeadline(_ time.Time) error  { return nil }
 func (c *proxyConn) SetWriteDeadline(_ time.Time) error { return nil }
@@ -130,10 +139,11 @@ func dialViaProxy(proxyCommand, originalHost string, settings *sshSettings) (net
 		waitCh <- cmd.Wait()
 	}()
 
-	// Check if process exited immediately (bad command, connection refused, etc.)
+	// Best-effort check for commands that fail immediately (bad command, connection
+	// refused, etc.). 100ms is enough for obvious failures while avoiding false
+	// positives on legitimate proxy commands that take a moment to connect.
 	select {
 	case err := <-waitCh:
-		// Process already exited, that's an error
 		stderr := strings.TrimSpace(stderrBuf.String())
 		if stderr != "" {
 			return nil, fmt.Errorf("proxy command exited immediately: %s", stderr)
@@ -142,8 +152,8 @@ func dialViaProxy(proxyCommand, originalHost string, settings *sshSettings) (net
 			return nil, fmt.Errorf("proxy command exited immediately: %w", err)
 		}
 		return nil, fmt.Errorf("proxy command exited immediately with no output")
-	case <-time.After(50 * time.Millisecond):
-		// Process is still running, good. It's acting as a proxy.
+	case <-time.After(100 * time.Millisecond):
+		// Process is still running, acting as a proxy.
 	}
 
 	conn := &proxyConn{

--- a/pkg/sshutil/proxy.go
+++ b/pkg/sshutil/proxy.go
@@ -1,0 +1,158 @@
+package sshutil
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"os/exec"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// expandProxyTokens expands SSH-style tokens in a ProxyCommand string.
+// Supported tokens: %h (hostname), %p (port), %n (original host alias),
+// %r (remote user), %% (literal %).
+func expandProxyTokens(cmd, originalHost, hostname, port, user string) string {
+	// Replace %% with a sentinel first so it doesn't get caught by other replacements
+	const sentinel = "\x00PERCENT\x00"
+	result := strings.ReplaceAll(cmd, "%%", sentinel)
+
+	result = strings.ReplaceAll(result, "%h", hostname)
+	result = strings.ReplaceAll(result, "%p", port)
+	result = strings.ReplaceAll(result, "%n", originalHost)
+	result = strings.ReplaceAll(result, "%r", user)
+
+	// Restore literal percent signs
+	result = strings.ReplaceAll(result, sentinel, "%")
+	return result
+}
+
+// proxyAddr implements net.Addr for proxy connections.
+type proxyAddr struct {
+	addr string
+}
+
+func (a proxyAddr) Network() string { return "proxy" }
+func (a proxyAddr) String() string  { return a.addr }
+
+// proxyConn wraps a subprocess's stdin/stdout as a net.Conn.
+// This is used to tunnel SSH connections through a ProxyCommand.
+type proxyConn struct {
+	cmd    *exec.Cmd
+	stdin  io.WriteCloser
+	stdout io.ReadCloser
+	addr   string     // remote address for RemoteAddr
+	waitCh chan error // receives cmd.Wait() result from background goroutine
+
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func (c *proxyConn) Read(b []byte) (int, error) {
+	return c.stdout.Read(b)
+}
+
+func (c *proxyConn) Write(b []byte) (int, error) {
+	return c.stdin.Write(b)
+}
+
+// Close terminates the proxy command process and cleans up resources.
+// It sends SIGTERM to the process group first, then SIGKILL after a grace period.
+func (c *proxyConn) Close() error {
+	c.closeOnce.Do(func() {
+		// Close stdin to signal EOF to the proxy process
+		c.stdin.Close()
+
+		// Try graceful shutdown: SIGTERM to process group
+		if c.cmd.Process != nil {
+			// Negative PID sends signal to the entire process group
+			_ = syscall.Kill(-c.cmd.Process.Pid, syscall.SIGTERM)
+		}
+
+		// Wait for process to exit with a grace period
+		select {
+		case <-c.waitCh:
+			// Process exited
+		case <-time.After(2 * time.Second):
+			// Force kill the process group
+			if c.cmd.Process != nil {
+				_ = syscall.Kill(-c.cmd.Process.Pid, syscall.SIGKILL)
+				<-c.waitCh
+			}
+		}
+
+		c.stdout.Close()
+	})
+	return c.closeErr
+}
+
+func (c *proxyConn) LocalAddr() net.Addr                { return proxyAddr{addr: "proxy"} }
+func (c *proxyConn) RemoteAddr() net.Addr               { return proxyAddr{addr: c.addr} }
+func (c *proxyConn) SetDeadline(_ time.Time) error      { return nil }
+func (c *proxyConn) SetReadDeadline(_ time.Time) error  { return nil }
+func (c *proxyConn) SetWriteDeadline(_ time.Time) error { return nil }
+
+// dialViaProxy establishes a connection through a ProxyCommand.
+// The proxy command is executed as a shell command, with its stdin/stdout
+// used as the transport for the SSH connection.
+func dialViaProxy(proxyCommand, originalHost string, settings *sshSettings) (net.Conn, error) {
+	expanded := expandProxyTokens(proxyCommand, originalHost, settings.hostname, settings.port, settings.user)
+
+	cmd := exec.Command("sh", "-c", expanded)
+
+	// Use process groups so we can kill the entire tree on cleanup
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("proxy stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("proxy stdout pipe: %w", err)
+	}
+
+	// Capture stderr for error reporting
+	var stderrBuf strings.Builder
+	cmd.Stderr = &stderrBuf
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("proxy command failed to start: %w", err)
+	}
+
+	// Start a goroutine to wait on the process. The result is used by both
+	// the early-exit check and proxyConn.Close().
+	waitCh := make(chan error, 1)
+	go func() {
+		waitCh <- cmd.Wait()
+	}()
+
+	// Check if process exited immediately (bad command, connection refused, etc.)
+	select {
+	case err := <-waitCh:
+		// Process already exited, that's an error
+		stderr := strings.TrimSpace(stderrBuf.String())
+		if stderr != "" {
+			return nil, fmt.Errorf("proxy command exited immediately: %s", stderr)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("proxy command exited immediately: %w", err)
+		}
+		return nil, fmt.Errorf("proxy command exited immediately with no output")
+	case <-time.After(50 * time.Millisecond):
+		// Process is still running, good. It's acting as a proxy.
+	}
+
+	conn := &proxyConn{
+		cmd:    cmd,
+		stdin:  stdin,
+		stdout: stdout,
+		addr:   net.JoinHostPort(settings.hostname, settings.port),
+		waitCh: waitCh,
+	}
+
+	return conn, nil
+}

--- a/pkg/sshutil/proxy.go
+++ b/pkg/sshutil/proxy.go
@@ -144,6 +144,9 @@ func dialViaProxy(proxyCommand, originalHost string, settings *sshSettings) (net
 	// positives on legitimate proxy commands that take a moment to connect.
 	select {
 	case err := <-waitCh:
+		// Process already exited - clean up pipes before returning
+		stdin.Close()
+		stdout.Close()
 		stderr := strings.TrimSpace(stderrBuf.String())
 		if stderr != "" {
 			return nil, fmt.Errorf("proxy command exited immediately: %s", stderr)

--- a/pkg/sshutil/proxy_test.go
+++ b/pkg/sshutil/proxy_test.go
@@ -1,0 +1,270 @@
+package sshutil
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpandProxyTokens(t *testing.T) {
+	tests := []struct {
+		name         string
+		cmd          string
+		originalHost string
+		hostname     string
+		port         string
+		user         string
+		expected     string
+	}{
+		{
+			name:         "hostname token",
+			cmd:          "nc %h 22",
+			originalHost: "myserver",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "root",
+			expected:     "nc 10.0.0.5 22",
+		},
+		{
+			name:         "port token",
+			cmd:          "nc host %p",
+			originalHost: "myserver",
+			hostname:     "10.0.0.5",
+			port:         "2222",
+			user:         "root",
+			expected:     "nc host 2222",
+		},
+		{
+			name:         "original host token",
+			cmd:          "ssh -W %h:%p %n-bastion",
+			originalHost: "myserver",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "root",
+			expected:     "ssh -W 10.0.0.5:22 myserver-bastion",
+		},
+		{
+			name:         "user token",
+			cmd:          "ssh -l %r bastion",
+			originalHost: "myserver",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "deploy",
+			expected:     "ssh -l deploy bastion",
+		},
+		{
+			name:         "literal percent",
+			cmd:          "echo 100%% done %h",
+			originalHost: "myserver",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "root",
+			expected:     "echo 100% done 10.0.0.5",
+		},
+		{
+			name:         "all tokens combined",
+			cmd:          "ssh -W %h:%p -l %r %n-bastion %%",
+			originalHost: "prod",
+			hostname:     "192.168.1.100",
+			port:         "30863",
+			user:         "admin",
+			expected:     "ssh -W 192.168.1.100:30863 -l admin prod-bastion %",
+		},
+		{
+			name:         "no tokens",
+			cmd:          "nc -X4 -x 192.168.100.23 10.30.121.100 30863",
+			originalHost: "server",
+			hostname:     "10.30.121.100",
+			port:         "30863",
+			user:         "root",
+			expected:     "nc -X4 -x 192.168.100.23 10.30.121.100 30863",
+		},
+		{
+			name:         "unknown percent token left as-is",
+			cmd:          "cmd %z %h",
+			originalHost: "server",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "root",
+			expected:     "cmd %z 10.0.0.5",
+		},
+		{
+			name:         "ProxyCommand from issue 190",
+			cmd:          "nc -X4 -x 192.168.100.23 %h %p",
+			originalHost: "A100server",
+			hostname:     "10.30.121.100",
+			port:         "30863",
+			user:         "root",
+			expected:     "nc -X4 -x 192.168.100.23 10.30.121.100 30863",
+		},
+		{
+			name:         "empty command",
+			cmd:          "",
+			originalHost: "server",
+			hostname:     "10.0.0.5",
+			port:         "22",
+			user:         "root",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := expandProxyTokens(tt.cmd, tt.originalHost, tt.hostname, tt.port, tt.user)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestProxyConn_ReadWriteClose(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh and cat")
+	}
+
+	// Use cat as a loopback proxy: what we write to stdin comes back on stdout
+	settings := &sshSettings{
+		hostname: "localhost",
+		port:     "22",
+		user:     "test",
+	}
+	conn, err := dialViaProxy("cat", "testhost", settings)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Write data through the proxy
+	msg := []byte("hello proxy")
+	n, err := conn.Write(msg)
+	require.NoError(t, err)
+	assert.Equal(t, len(msg), n)
+
+	// Read it back
+	buf := make([]byte, 64)
+	n, err = conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "hello proxy", string(buf[:n]))
+
+	// Verify addr methods don't panic
+	assert.Equal(t, "proxy", conn.LocalAddr().Network())
+	assert.Equal(t, "proxy", conn.LocalAddr().String())
+	assert.Equal(t, "proxy", conn.RemoteAddr().Network())
+	assert.Equal(t, "localhost:22", conn.RemoteAddr().String())
+
+	// Verify deadline no-ops return nil
+	assert.NoError(t, conn.SetDeadline(time.Now()))
+	assert.NoError(t, conn.SetReadDeadline(time.Now()))
+	assert.NoError(t, conn.SetWriteDeadline(time.Now()))
+}
+
+func TestProxyConn_CloseKillsProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh and sleep")
+	}
+
+	// Start a long-running proxy command
+	settings := &sshSettings{
+		hostname: "localhost",
+		port:     "22",
+		user:     "test",
+	}
+	conn, err := dialViaProxy("sleep 60", "testhost", settings)
+	require.NoError(t, err)
+
+	pc := conn.(*proxyConn)
+	pid := pc.cmd.Process.Pid
+
+	// Close should terminate the process
+	err = conn.Close()
+	assert.NoError(t, err)
+
+	// Verify the process is gone (kill -0 checks existence without sending a signal)
+	// Give it a moment for the OS to clean up
+	time.Sleep(100 * time.Millisecond)
+	err = exec.Command("kill", "-0", fmt.Sprintf("%d", pid)).Run()
+	assert.Error(t, err, "process should no longer exist after Close()")
+}
+
+func TestProxyConn_CloseIsIdempotent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh and cat")
+	}
+
+	settings := &sshSettings{
+		hostname: "localhost",
+		port:     "22",
+		user:     "test",
+	}
+	conn, err := dialViaProxy("cat", "testhost", settings)
+	require.NoError(t, err)
+
+	// Closing multiple times should not panic
+	assert.NoError(t, conn.Close())
+	assert.NoError(t, conn.Close())
+}
+
+func TestDialViaProxy_InvalidCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	settings := &sshSettings{
+		hostname: "localhost",
+		port:     "22",
+		user:     "test",
+	}
+
+	// A command that exits immediately with an error
+	_, err := dialViaProxy("false", "testhost", settings)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "proxy command exited immediately")
+}
+
+func TestDialViaProxy_NonexistentCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh")
+	}
+
+	settings := &sshSettings{
+		hostname: "localhost",
+		port:     "22",
+		user:     "test",
+	}
+
+	_, err := dialViaProxy("this_command_does_not_exist_xyz", "testhost", settings)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "proxy command exited immediately")
+}
+
+func TestDialViaProxy_TokenExpansion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("requires sh and echo/cat")
+	}
+
+	// Use a command that echoes the expanded tokens back to us, then acts as cat
+	// This verifies tokens are expanded before the command runs
+	settings := &sshSettings{
+		hostname: "10.0.0.5",
+		port:     "2222",
+		user:     "deploy",
+	}
+
+	// Use cat so the proxy stays alive; the expanded command should contain the right values
+	conn, err := dialViaProxy("cat", "myalias", settings)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Just verify the connection works (tokens don't affect cat, but this proves
+	// the flow works end-to-end)
+	msg := []byte("test")
+	_, err = conn.Write(msg)
+	require.NoError(t, err)
+
+	buf := make([]byte, 16)
+	n, err := conn.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, "test", string(buf[:n]))
+}

--- a/pkg/sshutil/proxy_test.go
+++ b/pkg/sshutil/proxy_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -177,9 +178,8 @@ func TestProxyConn_CloseKillsProcess(t *testing.T) {
 	pc := conn.(*proxyConn)
 	pid := pc.cmd.Process.Pid
 
-	// Close should terminate the process
-	err = conn.Close()
-	assert.NoError(t, err)
+	// Close should terminate the process. The exit error from SIGTERM is expected.
+	conn.Close()
 
 	// Verify the process is gone (kill -0 checks existence without sending a signal)
 	// Give it a moment for the OS to clean up
@@ -201,9 +201,9 @@ func TestProxyConn_CloseIsIdempotent(t *testing.T) {
 	conn, err := dialViaProxy("cat", "testhost", settings)
 	require.NoError(t, err)
 
-	// Closing multiple times should not panic
-	assert.NoError(t, conn.Close())
-	assert.NoError(t, conn.Close())
+	// Closing multiple times should not panic (exit error from SIGTERM is expected)
+	conn.Close()
+	conn.Close()
 }
 
 func TestDialViaProxy_InvalidCommand(t *testing.T) {
@@ -244,27 +244,21 @@ func TestDialViaProxy_TokenExpansion(t *testing.T) {
 		t.Skip("requires sh and echo/cat")
 	}
 
-	// Use a command that echoes the expanded tokens back to us, then acts as cat
-	// This verifies tokens are expanded before the command runs
 	settings := &sshSettings{
 		hostname: "10.0.0.5",
 		port:     "2222",
 		user:     "deploy",
 	}
 
-	// Use cat so the proxy stays alive; the expanded command should contain the right values
-	conn, err := dialViaProxy("cat", "myalias", settings)
+	// Use a shell that echoes the expanded tokens and then keeps running (cat).
+	// This verifies tokens are expanded before execution.
+	conn, err := dialViaProxy("echo '%h %p %n %r'; cat", "myalias", settings)
 	require.NoError(t, err)
 	defer conn.Close()
 
-	// Just verify the connection works (tokens don't affect cat, but this proves
-	// the flow works end-to-end)
-	msg := []byte("test")
-	_, err = conn.Write(msg)
-	require.NoError(t, err)
-
-	buf := make([]byte, 16)
+	buf := make([]byte, 128)
 	n, err := conn.Read(buf)
 	require.NoError(t, err)
-	assert.Equal(t, "test", string(buf[:n]))
+	output := strings.TrimSpace(string(buf[:n]))
+	assert.Equal(t, "10.0.0.5 2222 myalias deploy", output)
 }


### PR DESCRIPTION
## Summary

- Adds SSH `ProxyCommand` support so rr can connect through bastion hosts, SOCKS proxies, and other proxy configurations defined in `~/.ssh/config`
- Fixes rsync not picking up SSH config settings by always passing `-F ~/.ssh/config` to rsync's SSH subprocess
- Detects unsupported `ProxyJump` directives and emits a warning with a `ProxyCommand` conversion suggestion

Closes #190, closes #198

## How it works

**ProxyCommand (Issue #190):** When `ProxyCommand` is present in SSH config for a host, connections are routed through the proxy command's stdin/stdout instead of direct TCP. A new `proxyConn` type implements `net.Conn` by wrapping the subprocess pipes. SSH tokens (`%h`, `%p`, `%n`, `%r`, `%%`) are expanded before execution.

**rsync config (Issue #198):** Extracted a shared `buildSSHCmd()` helper that both sync and pull use. It always includes `-F ~/.ssh/config` (when the file exists) so rsync's SSH subprocess inherits ProxyCommand, IdentityFile, and other host-specific settings.

## Safety measures

- Process groups (`Setpgid`) ensure child processes spawned by proxy commands are cleaned up on close
- Graceful shutdown: SIGTERM first, SIGKILL after 2s grace period
- Handshake timeout via `time.AfterFunc` prevents hanging when proxy connects but SSH handshake stalls
- Early exit detection catches immediately-failing proxy commands with stderr output

## Test plan

- [x] `TestExpandProxyTokens` - all SSH token combinations including the exact ProxyCommand from issue #190
- [x] `TestProxyConn_ReadWriteClose` - I/O through `cat` as loopback proxy
- [x] `TestProxyConn_CloseKillsProcess` - subprocess termination verified via PID check
- [x] `TestProxyConn_CloseIsIdempotent` - double-close safety
- [x] `TestDialViaProxy_InvalidCommand` / `_NonexistentCommand` - error handling
- [x] `TestBuildSSHCmd` - SSH command construction with/without config file
- [x] Updated `TestBuildArgs_SSHConfigFile` for new default `-F` behavior
- [x] All existing tests pass, lint clean, pre-push hooks green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SSH ProxyCommand tunneling, ControlMaster connection reuse, and tighter SSH config integration for rsync/SSH invocations.

* **Tests**
  * Added comprehensive tests for proxy behavior, token expansion, SSH command construction, and connection handling.
  * Improved test robustness by ensuring immediate return after fatal test failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->