### PR TITLE
build(deps): bump go toolchain to 1.25.8 to fix govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.24.13
+go 1.25.8
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary

- Bumps Go toolchain from 1.24.13 to 1.25.8
- Fixes GO-2026-4602 (`os.FileInfo` escape from `Root`) security vulnerability
- Fixes coverage report CI failure where `gocovmerge`'s dependency on `golang.org/x/tools@v0.43.0` requires `go >= 1.25.0`

## Test plan

- [x] All tests pass locally
- [x] Lint clean
- [ ] CI should go green with this bump

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Go toolchain version to 1.25.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->