### PR TITLE
fix: SSH improvements - IdentityAgent, certificates, Ctrl+C, socket paths

### DIFF
--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -83,9 +83,14 @@ func Run(opts RunOptions) (int, error) {
 			cmd = strings.Join(wf.Resolved.Project.Defaults.Setup, " && ") + " && " + cmd
 		}
 		fullCmd := exec.BuildRemoteCommand(cmd, &wf.Conn.Host)
-		exitCode, err = wf.Conn.Client.ExecStream(fullCmd, streamHandler.Stdout(), streamHandler.Stderr())
+		exitCode, err = wf.Conn.Client.ExecStreamContext(wf.Context(), fullCmd, streamHandler.Stdout(), streamHandler.Stderr())
 	}
 	execDuration := time.Since(execStart)
+
+	// If cancelled by signal, return standard Ctrl+C exit code
+	if wf.Context().Err() != nil {
+		return 130, nil
+	}
 
 	if err != nil {
 		return 1, err

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -149,8 +149,13 @@ func RunTask(opts TaskOptions) (int, error) {
 	}
 
 	// Execute the task
-	result, err := exec.ExecuteTask(wf.Conn, task, opts.Args, mergedEnv, remoteDir, streamHandler.Stdout(), streamHandler.Stderr(), execOpts)
+	result, err := exec.ExecuteTask(wf.Context(), wf.Conn, task, opts.Args, mergedEnv, remoteDir, streamHandler.Stdout(), streamHandler.Stderr(), execOpts)
 	execDuration := time.Since(execStart)
+
+	// If cancelled by signal, return standard Ctrl+C exit code
+	if wf.Context().Err() != nil {
+		return 130, nil
+	}
 
 	if err != nil {
 		return 1, err

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -223,8 +223,8 @@ func runTaskWithDeps(wf *WorkflowContext, task *config.TaskConfig, opts TaskOpti
 
 	execStart := time.Now()
 
-	// Create execution context with optional timeout
-	ctx := context.Background()
+	// Create execution context from workflow (inherits signal cancellation)
+	ctx := wf.Context()
 	if task.Timeout != "" {
 		d, parseErr := time.ParseDuration(task.Timeout)
 		if parseErr != nil {

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -86,6 +86,9 @@ func (w *WorkflowContext) setupSignalHandler() {
 // when the user sends SIGINT/SIGTERM, allowing callers to propagate cancellation
 // to remote commands.
 func (w *WorkflowContext) Context() context.Context {
+	if w.ctx == nil {
+		return context.Background()
+	}
 	return w.ctx
 }
 

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -57,7 +57,7 @@ type WorkflowContext struct {
 // before the connection is torn down.
 func (w *WorkflowContext) setupSignalHandler() {
 	w.ctx, w.cancel = context.WithCancel(context.Background())
-	w.signalChan = make(chan os.Signal, 1)
+	w.signalChan = make(chan os.Signal, 2)
 	signal.Notify(w.signalChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
@@ -68,6 +68,16 @@ func (w *WorkflowContext) setupSignalHandler() {
 		}
 		// Cancel context first so in-flight SSH commands can clean up
 		w.cancel()
+
+		// Second signal force-quits immediately (users expect double Ctrl+C to kill)
+		go func() {
+			_, ok := <-w.signalChan
+			if !ok {
+				return
+			}
+			os.Exit(130)
+		}()
+
 		w.Close()
 	}()
 }

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/signal"
@@ -45,30 +46,46 @@ type WorkflowContext struct {
 	// Internal state
 	selector   *host.Selector
 	signalChan chan os.Signal
+	ctx        context.Context
+	cancel     context.CancelFunc
 	closeOnce  sync.Once
 }
 
 // setupSignalHandler registers interrupt handlers to ensure cleanup on Ctrl+C.
+// Instead of calling os.Exit, it cancels the workflow context so in-flight
+// commands (like remote SSH sessions) can send SIGINT to the remote process
+// before the connection is torn down.
 func (w *WorkflowContext) setupSignalHandler() {
+	w.ctx, w.cancel = context.WithCancel(context.Background())
 	w.signalChan = make(chan os.Signal, 1)
 	signal.Notify(w.signalChan, os.Interrupt, syscall.SIGTERM)
 
 	go func() {
-		sig, ok := <-w.signalChan
+		_, ok := <-w.signalChan
 		if !ok {
 			// Channel was closed by Close(), not a signal
 			return
 		}
-		// Received actual signal, clean up and exit
-		_ = sig
+		// Cancel context first so in-flight SSH commands can clean up
+		w.cancel()
 		w.Close()
-		os.Exit(130) // 128 + SIGINT(2) = 130, standard exit code for Ctrl+C
 	}()
+}
+
+// Context returns the workflow's cancellable context. This context is cancelled
+// when the user sends SIGINT/SIGTERM, allowing callers to propagate cancellation
+// to remote commands.
+func (w *WorkflowContext) Context() context.Context {
+	return w.ctx
 }
 
 // Close releases workflow resources. Safe to call multiple times.
 func (w *WorkflowContext) Close() {
 	w.closeOnce.Do(func() {
+		// Cancel context to signal in-flight operations
+		if w.cancel != nil {
+			w.cancel()
+		}
 		// Stop listening for signals
 		if w.signalChan != nil {
 			signal.Stop(w.signalChan)

--- a/internal/deps/executor.go
+++ b/internal/deps/executor.go
@@ -271,7 +271,7 @@ func (e *Executor) executeParallel(ctx context.Context, stage Stage) (*StageResu
 }
 
 // executeTask runs a single task.
-func (e *Executor) executeTask(_ context.Context, taskName string) *TaskExecutionResult {
+func (e *Executor) executeTask(ctx context.Context, taskName string) *TaskExecutionResult {
 	start := time.Now()
 	result := &TaskExecutionResult{
 		TaskName: taskName,
@@ -311,7 +311,7 @@ func (e *Executor) executeTask(_ context.Context, taskName string) *TaskExecutio
 		SetupCommands: e.opts.SetupCommands,
 	}
 
-	taskResult, err := exec.ExecuteTask(e.conn, &task, nil, mergedEnv, e.opts.WorkDir, e.opts.Stdout, e.opts.Stderr, execOpts)
+	taskResult, err := exec.ExecuteTask(ctx, e.conn, &task, nil, mergedEnv, e.opts.WorkDir, e.opts.Stdout, e.opts.Stderr, execOpts)
 	result.Duration = time.Since(start)
 
 	if err != nil {

--- a/internal/exec/task.go
+++ b/internal/exec/task.go
@@ -1,6 +1,7 @@
 package exec
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -51,7 +52,7 @@ type StepHandler interface {
 // ExecuteTask runs a task on the given connection.
 // Handles both single-command tasks (Run field) and multi-step tasks (Steps field).
 // Extra args are appended to single-command tasks (not supported for multi-step).
-func ExecuteTask(conn *host.Connection, task *config.TaskConfig, args []string, env map[string]string, workDir string, stdout, stderr io.Writer, opts *TaskExecOptions) (*TaskResult, error) {
+func ExecuteTask(ctx context.Context, conn *host.Connection, task *config.TaskConfig, args []string, env map[string]string, workDir string, stdout, stderr io.Writer, opts *TaskExecOptions) (*TaskResult, error) {
 	if task == nil {
 		return nil, errors.New(errors.ErrExec,
 			"No task provided",
@@ -70,7 +71,7 @@ func ExecuteTask(conn *host.Connection, task *config.TaskConfig, args []string, 
 		if len(args) > 0 {
 			cmd = cmd + " " + strings.Join(args, " ")
 		}
-		exitCode, err := executeCommand(conn, cmd, env, workDir, opts.SetupCommands, stdout, stderr)
+		exitCode, err := executeCommand(ctx, conn, cmd, env, workDir, opts.SetupCommands, stdout, stderr)
 		if err != nil {
 			return nil, err
 		}
@@ -87,11 +88,11 @@ func ExecuteTask(conn *host.Connection, task *config.TaskConfig, args []string, 
 			"Add a 'run' command or 'steps' to your task config.")
 	}
 
-	return executeSteps(conn, task.Steps, env, workDir, opts, stdout, stderr)
+	return executeSteps(ctx, conn, task.Steps, env, workDir, opts, stdout, stderr)
 }
 
 // executeSteps runs multiple steps in sequence.
-func executeSteps(conn *host.Connection, steps []config.TaskStep, env map[string]string, workDir string, opts *TaskExecOptions, stdout, stderr io.Writer) (*TaskResult, error) {
+func executeSteps(ctx context.Context, conn *host.Connection, steps []config.TaskStep, env map[string]string, workDir string, opts *TaskExecOptions, stdout, stderr io.Writer) (*TaskResult, error) {
 	result := &TaskResult{
 		StepResults: make([]StepResult, 0, len(steps)),
 		FailedStep:  -1,
@@ -100,6 +101,13 @@ func executeSteps(conn *host.Connection, steps []config.TaskStep, env map[string
 	totalSteps := len(steps)
 
 	for i, step := range steps {
+		// Check for cancellation between steps
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		default:
+		}
+
 		stepNum := i + 1
 		stepResult := StepResult{
 			Name:   step.Name,
@@ -116,7 +124,7 @@ func executeSteps(conn *host.Connection, steps []config.TaskStep, env map[string
 		}
 
 		stepStart := time.Now()
-		exitCode, err := executeCommand(conn, step.Run, env, workDir, opts.SetupCommands, stdout, stderr)
+		exitCode, err := executeCommand(ctx, conn, step.Run, env, workDir, opts.SetupCommands, stdout, stderr)
 		stepDuration := time.Since(stepStart)
 
 		if err != nil {
@@ -150,7 +158,7 @@ func executeSteps(conn *host.Connection, steps []config.TaskStep, env map[string
 }
 
 // executeCommand runs a single command on the connection.
-func executeCommand(conn *host.Connection, cmd string, env map[string]string, workDir string, setupCommands []string, stdout, stderr io.Writer) (int, error) {
+func executeCommand(ctx context.Context, conn *host.Connection, cmd string, env map[string]string, workDir string, setupCommands []string, stdout, stderr io.Writer) (int, error) {
 	// Build the full command with environment variables, working directory, and setup commands
 	fullCmd := buildCommand(cmd, env, workDir, setupCommands, conn.IsLocal)
 
@@ -159,7 +167,7 @@ func executeCommand(conn *host.Connection, cmd string, env map[string]string, wo
 	}
 
 	// Remote execution
-	return conn.Client.ExecStream(fullCmd, stdout, stderr)
+	return conn.Client.ExecStreamContext(ctx, fullCmd, stdout, stderr)
 }
 
 // buildCommand constructs the full command string with setup commands, env vars, and cd.
@@ -215,7 +223,7 @@ func ExecuteLocalTask(task *config.TaskConfig, env map[string]string) (*TaskResu
 		IsLocal: true,
 	}
 
-	return ExecuteTask(conn, task, nil, env, workDir, os.Stdout, os.Stderr, nil)
+	return ExecuteTask(context.Background(), conn, task, nil, env, workDir, os.Stdout, os.Stderr, nil)
 }
 
 // DefaultShell is used when no shell is configured.

--- a/internal/exec/task.go
+++ b/internal/exec/task.go
@@ -104,7 +104,9 @@ func executeSteps(ctx context.Context, conn *host.Connection, steps []config.Tas
 		// Check for cancellation between steps
 		select {
 		case <-ctx.Done():
-			return result, ctx.Err()
+			return result, errors.WrapWithCode(ctx.Err(), errors.ErrExec,
+				"task execution canceled",
+				"The task was interrupted (e.g. Ctrl+C).")
 		default:
 		}
 

--- a/internal/exec/task_test.go
+++ b/internal/exec/task_test.go
@@ -2,6 +2,7 @@ package exec
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/rileyhilliard/rr/internal/config"
@@ -26,7 +27,7 @@ func TestExecuteTask_SingleCommand(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.ExitCode)
@@ -43,7 +44,7 @@ func TestExecuteTask_SingleCommandWithArgs(t *testing.T) {
 	args := []string{"world", "foo"}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, args, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, args, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.ExitCode)
@@ -59,7 +60,7 @@ func TestExecuteTask_SingleCommandWithEnv(t *testing.T) {
 	env := map[string]string{"MY_VAR": "test_value"}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, env, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, env, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.ExitCode)
@@ -73,7 +74,7 @@ func TestExecuteTask_SingleCommandFailure(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err) // No error - command ran but returned non-zero
 	assert.Equal(t, 42, result.ExitCode)
@@ -91,7 +92,7 @@ func TestExecuteTask_MultiStepAllPassing(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.ExitCode)
@@ -119,7 +120,7 @@ func TestExecuteTask_MultiStepFailureWithStop(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.ExitCode)
@@ -146,7 +147,7 @@ func TestExecuteTask_MultiStepFailureWithContinue(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.ExitCode)   // Final exit code is from failed step
@@ -175,7 +176,7 @@ func TestExecuteTask_MultiStepMixedOnFail(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.Equal(t, 2, result.ExitCode)   // Exit code from step3
@@ -203,7 +204,7 @@ func TestExecuteTask_StepNamesDefault(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	require.Len(t, result.StepResults, 3)
@@ -224,7 +225,7 @@ func TestExecuteTask_OnFailDefaults(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	require.Len(t, result.StepResults, 4)
@@ -240,7 +241,7 @@ func TestExecuteTask_NilTask(t *testing.T) {
 	conn := createLocalConn()
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, nil, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, nil, nil, nil, "", &stdout, &stderr, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, result)
@@ -252,7 +253,7 @@ func TestExecuteTask_EmptyTask(t *testing.T) {
 	task := &config.TaskConfig{}
 
 	var stdout, stderr bytes.Buffer
-	result, err := ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.Error(t, err)
 	assert.Nil(t, result)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -17,8 +17,9 @@ import (
 )
 
 // controlSocketDir is the directory for SSH ControlMaster sockets.
-// Using /tmp for cross-platform compatibility.
-var controlSocketDir = filepath.Join(os.TempDir(), "rr-ssh")
+// Uses /tmp with per-user namespacing to keep paths short (macOS has a 104-byte
+// Unix socket path limit, and os.TempDir() returns long /var/folders/... paths).
+var controlSocketDir = fmt.Sprintf("/tmp/rr-ssh-%d", os.Getuid())
 
 // SSHConfigFile can be set to use a custom SSH config file for rsync.
 // If empty, uses the default SSH config. Useful for testing with custom

--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -445,15 +445,19 @@ func sshAgentAuth(identityAgent string) ssh.AuthMethod {
 		if err != nil {
 			return nil
 		}
-		perHostAgentConnsMu.Lock()
-		perHostAgentConns = append(perHostAgentConns, conn)
-		perHostAgentConnsMu.Unlock()
 
 		client := agent.NewClient(conn)
 		signers, err := client.Signers()
 		if err != nil || len(signers) == 0 {
+			conn.Close()
 			return nil
 		}
+
+		// Only track the connection for cleanup if we're actually using it
+		perHostAgentConnsMu.Lock()
+		perHostAgentConns = append(perHostAgentConns, conn)
+		perHostAgentConnsMu.Unlock()
+
 		return ssh.PublicKeysCallback(client.Signers)
 	}
 
@@ -524,13 +528,15 @@ func keyFileAuth(keyPath string) (ssh.AuthMethod, error) {
 	// If found, combine it with the private key for certificate-based auth.
 	certPath := keyPath + "-cert.pub"
 	if certData, err := os.ReadFile(certPath); err == nil {
-		pubKey, _, _, _, err := ssh.ParseAuthorizedKey(certData)
-		if err == nil {
-			if cert, ok := pubKey.(*ssh.Certificate); ok {
-				if certSigner, err := ssh.NewCertSigner(cert, signer); err == nil {
-					return ssh.PublicKeys(certSigner), nil
-				}
-			}
+		pubKey, _, _, _, parseErr := ssh.ParseAuthorizedKey(certData)
+		if parseErr != nil {
+			emitWarning(fmt.Sprintf("Found certificate %s but couldn't parse it: %v", certPath, parseErr))
+		} else if cert, ok := pubKey.(*ssh.Certificate); !ok {
+			emitWarning(fmt.Sprintf("Found %s but it's not a certificate", certPath))
+		} else if certSigner, certErr := ssh.NewCertSigner(cert, signer); certErr != nil {
+			emitWarning(fmt.Sprintf("Found certificate %s but couldn't use it: %v", certPath, certErr))
+		} else {
+			return ssh.PublicKeys(certSigner), nil
 		}
 	}
 

--- a/pkg/sshutil/client.go
+++ b/pkg/sshutil/client.go
@@ -180,6 +180,7 @@ type sshSettings struct {
 	user          string
 	identityFile  string
 	proxyCommand  string   // ProxyCommand from SSH config (if any)
+	identityAgent string   // IdentityAgent socket path from SSH config (if any)
 	encryptedKeys []string // Keys that exist but are encrypted
 }
 
@@ -280,6 +281,14 @@ func resolveSSHSettings(host string) *sshSettings {
 		hostFound = true
 	}
 
+	// Get IdentityAgent (e.g. 1Password, YubiKey agent sockets)
+	if identityAgent, _ := cfg.Get(host, "IdentityAgent"); identityAgent != "" {
+		// Expand env vars first ($SSH_AUTH_SOCK), then tilde (~/)
+		expanded := os.ExpandEnv(identityAgent)
+		settings.identityAgent = expandPath(expanded)
+		hostFound = true
+	}
+
 	// Warn about ProxyJump (not yet supported, but detectable)
 	if settings.proxyCommand == "" {
 		if proxyJump, _ := cfg.Get(host, "ProxyJump"); proxyJump != "" {
@@ -340,7 +349,7 @@ func buildSSHConfig(settings *sshSettings) (*ssh.ClientConfig, error) {
 	} else {
 		// Normal mode: try multiple auth methods
 		// Try SSH agent first (most common and convenient)
-		if agentAuth := sshAgentAuth(); agentAuth != nil {
+		if agentAuth := sshAgentAuth(settings.identityAgent); agentAuth != nil {
 			authMethods = append(authMethods, agentAuth)
 		}
 
@@ -407,17 +416,48 @@ func buildSSHConfig(settings *sshSettings) (*ssh.ClientConfig, error) {
 	}, nil
 }
 
-// agentConn holds the reusable SSH agent connection.
+// agentConn holds the reusable SSH agent connection for the default SSH_AUTH_SOCK.
 var (
 	agentConn     net.Conn
 	agentClient   agent.ExtendedAgent
 	agentConnOnce sync.Once
 )
 
+// perHostAgentConns tracks agent connections opened for per-host IdentityAgent sockets.
+var (
+	perHostAgentConns   []net.Conn
+	perHostAgentConnsMu sync.Mutex
+)
+
 // sshAgentAuth returns an auth method using the SSH agent if available.
-// The agent connection is reused across multiple SSH connections.
-// Returns nil if the agent has no keys loaded.
-func sshAgentAuth() ssh.AuthMethod {
+// If identityAgent is set, it uses that socket path instead of SSH_AUTH_SOCK.
+// If identityAgent is "none", agent auth is explicitly disabled.
+// The default SSH_AUTH_SOCK connection is cached; per-host connections are tracked for cleanup.
+func sshAgentAuth(identityAgent string) ssh.AuthMethod {
+	if identityAgent == "none" {
+		return nil
+	}
+
+	// Per-host IdentityAgent: open a dedicated connection (not cached globally
+	// since different hosts may use different agent sockets)
+	if identityAgent != "" {
+		conn, err := net.Dial("unix", identityAgent)
+		if err != nil {
+			return nil
+		}
+		perHostAgentConnsMu.Lock()
+		perHostAgentConns = append(perHostAgentConns, conn)
+		perHostAgentConnsMu.Unlock()
+
+		client := agent.NewClient(conn)
+		signers, err := client.Signers()
+		if err != nil || len(signers) == 0 {
+			return nil
+		}
+		return ssh.PublicKeysCallback(client.Signers)
+	}
+
+	// Default: use SSH_AUTH_SOCK with cached connection
 	socket := os.Getenv("SSH_AUTH_SOCK")
 	if socket == "" {
 		return nil
@@ -446,12 +486,18 @@ func sshAgentAuth() ssh.AuthMethod {
 	return ssh.PublicKeysCallback(agentClient.Signers)
 }
 
-// CloseAgent closes the SSH agent connection if one is open.
+// CloseAgent closes all SSH agent connections (both default and per-host).
 // This should be called when the application is shutting down.
 func CloseAgent() {
 	if agentConn != nil {
 		agentConn.Close()
 	}
+	perHostAgentConnsMu.Lock()
+	for _, conn := range perHostAgentConns {
+		conn.Close()
+	}
+	perHostAgentConns = nil
+	perHostAgentConnsMu.Unlock()
 }
 
 // keyFileAuth returns an auth method using a private key file.
@@ -472,6 +518,20 @@ func keyFileAuth(keyPath string) (ssh.AuthMethod, error) {
 			return nil, &EncryptedKeyError{Path: keyPath}
 		}
 		return nil, err
+	}
+
+	// Check for an accompanying SSH certificate file (e.g. id_ed25519-cert.pub).
+	// If found, combine it with the private key for certificate-based auth.
+	certPath := keyPath + "-cert.pub"
+	if certData, err := os.ReadFile(certPath); err == nil {
+		pubKey, _, _, _, err := ssh.ParseAuthorizedKey(certData)
+		if err == nil {
+			if cert, ok := pubKey.(*ssh.Certificate); ok {
+				if certSigner, err := ssh.NewCertSigner(cert, signer); err == nil {
+					return ssh.PublicKeys(certSigner), nil
+				}
+			}
+		}
 	}
 
 	return ssh.PublicKeys(signer), nil

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -1001,7 +1001,7 @@ func TestSshAgentAuth_NoSocket(t *testing.T) {
 	os.Unsetenv("SSH_AUTH_SOCK")
 	defer os.Setenv("SSH_AUTH_SOCK", orig)
 
-	result := sshAgentAuth()
+	result := sshAgentAuth("")
 	assert.Nil(t, result)
 }
 
@@ -1488,7 +1488,7 @@ func TestSshAgentAuth_InvalidSocket(t *testing.T) {
 	// Reset agent state to force reconnection attempt
 	// Note: Due to sync.Once, this might not trigger new connection
 	// But we're testing the code path doesn't panic
-	result := sshAgentAuth()
+	result := sshAgentAuth("")
 
 	// Result can be nil (no valid agent) or non-nil (if agent was cached)
 	_ = result

--- a/pkg/sshutil/client_test.go
+++ b/pkg/sshutil/client_test.go
@@ -1494,6 +1494,16 @@ func TestSshAgentAuth_InvalidSocket(t *testing.T) {
 	_ = result
 }
 
+func TestSshAgentAuth_NoneDisablesAgent(t *testing.T) {
+	result := sshAgentAuth("none")
+	assert.Nil(t, result, "IdentityAgent='none' should disable agent auth")
+}
+
+func TestSshAgentAuth_InvalidSocketPath(t *testing.T) {
+	result := sshAgentAuth("/nonexistent/agent.sock")
+	assert.Nil(t, result, "Invalid socket path should return nil without panic")
+}
+
 // Tests for buildSSHConfig with strict host key checking
 
 func TestBuildSSHConfig_StrictHostKeyChecking(t *testing.T) {

--- a/pkg/sshutil/exec.go
+++ b/pkg/sshutil/exec.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"time"
 
 	"github.com/rileyhilliard/rr/internal/errors"
 	"golang.org/x/crypto/ssh"
@@ -82,12 +83,11 @@ func (c *Client) ExecStreamContext(ctx context.Context, cmd string, stdout, stde
 	case <-ctx.Done():
 		// Context cancelled - send SIGINT to the remote process
 		_ = session.Signal(ssh.SIGINT)
-		// Give it a moment to terminate gracefully, then force close
+		// Give the remote process time to handle SIGINT before force-closing
 		select {
 		case runErr := <-done:
 			return exitCodeFromError(runErr), ctx.Err()
-		default:
-			// Force close the session if it doesn't respond to SIGINT
+		case <-time.After(3 * time.Second):
 			session.Close()
 			return 130, ctx.Err()
 		}

--- a/tests/integration/exec_ssh_test.go
+++ b/tests/integration/exec_ssh_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -256,7 +257,7 @@ func TestExecuteTask(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, nil, nil, conn.Host.Dir, &stdout, &stderr, nil)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, nil, nil, conn.Host.Dir, &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -275,7 +276,7 @@ func TestExecuteTaskWithArgs(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, []string{"arg1", "arg2"}, nil, conn.Host.Dir, &stdout, &stderr, nil)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, []string{"arg1", "arg2"}, nil, conn.Host.Dir, &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -299,7 +300,7 @@ func TestExecuteTaskWithEnv(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, nil, env, conn.Host.Dir, &stdout, &stderr, nil)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, nil, env, conn.Host.Dir, &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -322,7 +323,7 @@ func TestExecuteMultiStepTask(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, nil, nil, conn.Host.Dir, &stdout, &stderr, nil)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, nil, nil, conn.Host.Dir, &stdout, &stderr, nil)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)
@@ -343,7 +344,7 @@ func TestExecuteTaskFailure(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, nil)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, nil)
 
 	require.NoError(t, err, "ExecuteTask should not return error for command failure")
 	assert.NotNil(t, result)
@@ -363,7 +364,7 @@ func TestExecuteTaskWithSetupCommands(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	result, err := exec.ExecuteTask(conn, task, nil, nil, "", &stdout, &stderr, opts)
+	result, err := exec.ExecuteTask(context.Background(), conn, task, nil, nil, "", &stdout, &stderr, opts)
 
 	require.NoError(t, err)
 	assert.NotNil(t, result)


### PR DESCRIPTION
## Summary

Fixes four SSH-related bugs reported in #195, #196, #197, #199:

- **IdentityAgent support (#195):** Parse `IdentityAgent` from SSH config so hosts using 1Password, YubiKey, or custom agent sockets work correctly. Falls back to `SSH_AUTH_SOCK` when not set. Per-host agent connections are tracked and cleaned up on shutdown.
- **Ctrl+C remote process cleanup (#196):** Refactored the workflow signal handler to use context cancellation instead of `os.Exit(130)`. This lets in-flight SSH sessions send SIGINT to the remote process before tearing down the connection. Also adds a 3-second grace period in `ExecStreamContext` before force-closing the session.
- **SSH certificate authentication (#197):** `keyFileAuth()` now checks for companion `-cert.pub` certificate files alongside private keys and uses `ssh.NewCertSigner` when found. Falls back to regular key auth if no cert exists.
- **Unix socket path length (#199):** Changed ControlMaster socket directory from `os.TempDir()` (which returns long `/var/folders/...` paths on macOS) to `/tmp/rr-ssh-<uid>`, staying well within the 104-byte Unix socket limit while avoiding multi-user conflicts.

## Test plan

- [x] All unit tests pass (`go test ./...`)
- [x] Race detector clean (`go test -race ./...`)
- [x] Lint clean (`golangci-lint run`)
- [x] Pre-commit and pre-push hooks pass
- [ ] Manual: `rr run "sleep 60"` + Ctrl+C terminates remote process
- [ ] Manual: Host with `IdentityAgent` in SSH config connects successfully

Closes #195, closes #196, closes #197, closes #199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved interrupt handling so cancelled runs return a standard exit code (Ctrl+C) and in-progress remote commands get a short graceful shutdown window.
  * SSH remote sessions now wait briefly for clean termination before force-closing.

* **New Features**
  * Per-user SSH control socket directory for more reliable connections.
  * Support for IdentityAgent settings and OpenSSH certificate-based key loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->