### PR TITLE
build(deps): bump go toolchain to 1.25.10 to fix govulncheck

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary
- Bumps Go toolchain from 1.25.8 to 1.25.10
- Fixes 6 stdlib vulnerabilities flagged by govulncheck (GO-2026-4971, GO-2026-4947, GO-2026-4946, GO-2026-4918, GO-2026-4870, GO-2026-4869)
- Affected packages: net, crypto/x509, crypto/tls, net/http, archive/tar

## Test plan
- [x] `go build ./...` passes
- [x] All unit tests pass
- [x] Lint clean