### PR TITLE
feat: v0.22.0 - agent friction fixes + security patches

### DIFF
--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -20,6 +20,7 @@ var (
 	runRepeatFlag            int
 	runPullFlags             []string
 	runPullDestFlag          string
+	runCwdFlag               string
 	execHostFlag             string
 	execTagFlag              string
 	execProbeTimeoutFlag     string
@@ -27,6 +28,7 @@ var (
 	execSkipRequirementsFlag bool
 	execPullFlags            []string
 	execPullDestFlag         string
+	execCwdFlag              string
 	syncHostFlag             string
 	syncTagFlag              string
 	syncProbeTimeoutFlag     string
@@ -71,7 +73,7 @@ Examples:
 				fmt.Sprintf("--repeat must be >= 0, got %d", runRepeatFlag),
 				"Use --repeat with a positive number like --repeat 5")
 		}
-		return runCommand(args, runHostFlag, runTagFlag, runProbeTimeoutFlag, runLocalFlag, runSkipRequirementsFlag, runRepeatFlag, runPullFlags, runPullDestFlag)
+		return runCommand(args, runHostFlag, runTagFlag, runProbeTimeoutFlag, runLocalFlag, runSkipRequirementsFlag, runRepeatFlag, runPullFlags, runPullDestFlag, runCwdFlag)
 	},
 }
 
@@ -89,7 +91,7 @@ Examples:
   rr exec "cat /var/log/app.log"`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return execCommand(args, execHostFlag, execTagFlag, execProbeTimeoutFlag, execLocalFlag, execSkipRequirementsFlag, execPullFlags, execPullDestFlag)
+		return execCommand(args, execHostFlag, execTagFlag, execProbeTimeoutFlag, execLocalFlag, execSkipRequirementsFlag, execPullFlags, execPullDestFlag, execCwdFlag)
 	},
 }
 
@@ -470,6 +472,7 @@ func init() {
 	runCmd.Flags().IntVar(&runRepeatFlag, "repeat", 0, "run command N times in parallel across available hosts (for flake detection)")
 	runCmd.Flags().StringArrayVar(&runPullFlags, "pull", nil, "pull files from remote after command (can be repeated)")
 	runCmd.Flags().StringVar(&runPullDestFlag, "pull-dest", "", "destination directory for pulled files (default: current directory)")
+	runCmd.Flags().StringVar(&runCwdFlag, "cwd", "", "subdirectory to cd into on remote before running (relative to project root)")
 
 	// exec command flags
 	execCmd.Flags().StringVar(&execHostFlag, "host", "", "target host name")
@@ -479,6 +482,7 @@ func init() {
 	execCmd.Flags().BoolVar(&execLocalFlag, "local", false, "force local execution (skip remote hosts)")
 	execCmd.Flags().StringArrayVar(&execPullFlags, "pull", nil, "pull files from remote after command (can be repeated)")
 	execCmd.Flags().StringVar(&execPullDestFlag, "pull-dest", "", "destination directory for pulled files (default: current directory)")
+	execCmd.Flags().StringVar(&execCwdFlag, "cwd", "", "subdirectory to cd into on remote before running (relative to project root)")
 
 	// sync command flags
 	syncCmd.Flags().StringVar(&syncHostFlag, "host", "", "target host name")

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/rileyhilliard/rr/internal/errors"
+	"github.com/rileyhilliard/rr/internal/ui"
 	"github.com/spf13/cobra"
 )
 
@@ -228,6 +229,13 @@ Examples:
   rr monitor
   rr monitor --hosts mini,workstation
   rr monitor --interval 5s`,
+	PreRun: func(cmd *cobra.Command, args []string) {
+		// Monitor is always an interactive TUI, so force colors on
+		// even though the default output mode is machine-readable.
+		if !noColor {
+			ui.EnableColors()
+		}
+	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Parse interval
 		interval := 2 * time.Second

--- a/internal/cli/exec_cmd.go
+++ b/internal/cli/exec_cmd.go
@@ -8,7 +8,7 @@ import (
 
 // execCommand executes a command without syncing files first.
 // This shares the core logic with run but skips the sync phase.
-func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag, skipRequirementsFlag bool, pullPatterns []string, pullDest string) error {
+func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag, skipRequirementsFlag bool, pullPatterns []string, pullDest, remoteCWD string) error {
 	if len(args) == 0 {
 		return errors.New(errors.ErrExec,
 			"What should I run?",
@@ -34,6 +34,7 @@ func execCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, loca
 		Local:            localFlag,
 		Pull:             pullPatterns,
 		PullDest:         pullDest,
+		RemoteCWD:        remoteCWD,
 	})
 
 	if err != nil {

--- a/internal/cli/json.go
+++ b/internal/cli/json.go
@@ -18,6 +18,9 @@ var machineMode bool
 // prettyMode flag - when true, use human-readable output with spinners and colors
 var prettyMode bool
 
+// suppressPhases - when true, intermediate phase events are suppressed (result events still emitted)
+var suppressPhases bool
+
 // MachineMode returns true if machine-readable output is enabled.
 // With structured output as default, this is always true unless --pretty is set.
 func MachineMode() bool {
@@ -43,7 +46,12 @@ type PhaseEvent struct {
 }
 
 // WritePhaseEvent writes a structured phase event to stderr as a JSON line.
+// Intermediate phase events (type "phase") are suppressed when --no-phases is set.
+// Result events (type "result") are always emitted.
 func WritePhaseEvent(event PhaseEvent) {
+	if suppressPhases && event.Type == "phase" {
+		return
+	}
 	event.TS = time.Now().UTC().Format(time.RFC3339)
 	data, err := json.Marshal(event)
 	if err != nil {

--- a/internal/cli/json_test.go
+++ b/internal/cli/json_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/rileyhilliard/rr/internal/errors"
@@ -526,4 +528,70 @@ func TestErrorCodes_Format(t *testing.T) {
 			}
 		}
 	}
+}
+
+// captureStderr captures os.Stderr output during fn execution.
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func TestWritePhaseEvent_SuppressedWhenNoPhasesSet(t *testing.T) {
+	old := suppressPhases
+	defer func() { suppressPhases = old }()
+
+	suppressPhases = true
+
+	output := captureStderr(func() {
+		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "connect", Status: "started"})
+	})
+
+	assert.Empty(t, output, "phase event should be suppressed when --no-phases is set")
+}
+
+func TestWritePhaseEvent_SyncSuppressedWhenNoPhasesSet(t *testing.T) {
+	old := suppressPhases
+	defer func() { suppressPhases = old }()
+
+	suppressPhases = true
+
+	output := captureStderr(func() {
+		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "sync", Status: "started"})
+	})
+
+	assert.Empty(t, output, "sync phase event should be suppressed")
+}
+
+func TestWritePhaseEvent_ResultNotSuppressedWhenNoPhasesSet(t *testing.T) {
+	old := suppressPhases
+	defer func() { suppressPhases = old }()
+
+	suppressPhases = true
+
+	output := captureStderr(func() {
+		WritePhaseEvent(PhaseEvent{Type: "result", Status: "success"})
+	})
+
+	assert.NotEmpty(t, output, "result event must not be suppressed even with --no-phases")
+	assert.Contains(t, output, `"type":"result"`)
+}
+
+func TestWritePhaseEvent_EmittedWhenNoPhasesNotSet(t *testing.T) {
+	old := suppressPhases
+	defer func() { suppressPhases = old }()
+
+	suppressPhases = false
+
+	output := captureStderr(func() {
+		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "connect", Status: "started"})
+	})
+
+	assert.NotEmpty(t, output, "phase event should be emitted when suppressPhases is false")
 }

--- a/internal/cli/json_test.go
+++ b/internal/cli/json_test.go
@@ -531,67 +531,77 @@ func TestErrorCodes_Format(t *testing.T) {
 }
 
 // captureStderr captures os.Stderr output during fn execution.
-func captureStderr(fn func()) string {
+// Uses defer to restore os.Stderr even if fn panics.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
 	old := os.Stderr
-	r, w, _ := os.Pipe()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
 	os.Stderr = w
+	defer func() {
+		os.Stderr = old
+		r.Close()
+	}()
 	fn()
 	w.Close()
-	os.Stderr = old
 	var buf bytes.Buffer
 	_, _ = io.Copy(&buf, r)
 	return buf.String()
 }
 
-func TestWritePhaseEvent_SuppressedWhenNoPhasesSet(t *testing.T) {
-	old := suppressPhases
-	defer func() { suppressPhases = old }()
+func TestWritePhaseEvent_SuppressPhasesBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		suppress     bool
+		event        PhaseEvent
+		wantEmpty    bool
+		wantContains string
+	}{
+		{
+			name:      "phase event suppressed when flag set",
+			suppress:  true,
+			event:     PhaseEvent{Type: "phase", Phase: "connect", Status: "started"},
+			wantEmpty: true,
+		},
+		{
+			name:      "sync phase event suppressed when flag set",
+			suppress:  true,
+			event:     PhaseEvent{Type: "phase", Phase: "sync", Status: "started"},
+			wantEmpty: true,
+		},
+		{
+			name:         "result event not suppressed even when flag set",
+			suppress:     true,
+			event:        PhaseEvent{Type: "result", Status: "success"},
+			wantEmpty:    false,
+			wantContains: `"type":"result"`,
+		},
+		{
+			name:      "phase event emitted when flag not set",
+			suppress:  false,
+			event:     PhaseEvent{Type: "phase", Phase: "connect", Status: "started"},
+			wantEmpty: false,
+		},
+	}
 
-	suppressPhases = true
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			old := suppressPhases
+			defer func() { suppressPhases = old }()
+			suppressPhases = tt.suppress
 
-	output := captureStderr(func() {
-		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "connect", Status: "started"})
-	})
+			output := captureStderr(t, func() {
+				WritePhaseEvent(tt.event)
+			})
 
-	assert.Empty(t, output, "phase event should be suppressed when --no-phases is set")
-}
-
-func TestWritePhaseEvent_SyncSuppressedWhenNoPhasesSet(t *testing.T) {
-	old := suppressPhases
-	defer func() { suppressPhases = old }()
-
-	suppressPhases = true
-
-	output := captureStderr(func() {
-		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "sync", Status: "started"})
-	})
-
-	assert.Empty(t, output, "sync phase event should be suppressed")
-}
-
-func TestWritePhaseEvent_ResultNotSuppressedWhenNoPhasesSet(t *testing.T) {
-	old := suppressPhases
-	defer func() { suppressPhases = old }()
-
-	suppressPhases = true
-
-	output := captureStderr(func() {
-		WritePhaseEvent(PhaseEvent{Type: "result", Status: "success"})
-	})
-
-	assert.NotEmpty(t, output, "result event must not be suppressed even with --no-phases")
-	assert.Contains(t, output, `"type":"result"`)
-}
-
-func TestWritePhaseEvent_EmittedWhenNoPhasesNotSet(t *testing.T) {
-	old := suppressPhases
-	defer func() { suppressPhases = old }()
-
-	suppressPhases = false
-
-	output := captureStderr(func() {
-		WritePhaseEvent(PhaseEvent{Type: "phase", Phase: "connect", Status: "started"})
-	})
-
-	assert.NotEmpty(t, output, "phase event should be emitted when suppressPhases is false")
+			if tt.wantEmpty {
+				assert.Empty(t, output)
+			} else {
+				assert.NotEmpty(t, output)
+			}
+			if tt.wantContains != "" {
+				assert.Contains(t, output, tt.wantContains)
+			}
+		})
+	}
 }

--- a/internal/cli/parallel.go
+++ b/internal/cli/parallel.go
@@ -29,6 +29,7 @@ type ParallelTaskOptions struct {
 	DryRun      bool          // Show plan only, don't execute
 	Local       bool          // Force local execution
 	Timeout     time.Duration // Per-task timeout
+	Args        []string      // Extra args forwarded to subtasks when forward_args is true
 }
 
 // RunParallelTask executes a parallel task group.
@@ -65,26 +66,9 @@ func RunParallelTask(opts ParallelTaskOptions) (int, error) {
 	}
 
 	// Build TaskInfo for each flattened subtask
-	tasks := make([]parallel.TaskInfo, 0, len(flattenedNames))
-	for i, subtaskName := range flattenedNames {
-		subtask, err := config.GetTask(resolved.Project, subtaskName)
-		if err != nil {
-			return 1, err
-		}
-
-		// Build the command
-		cmd := subtask.Run
-		if cmd == "" && len(subtask.Steps) > 0 {
-			// For multi-step tasks, build a command that runs all steps
-			cmd = buildStepsCommand(subtask.Steps)
-		}
-
-		tasks = append(tasks, parallel.TaskInfo{
-			Name:    subtaskName,
-			Index:   i, // Unique index for duplicate name handling
-			Command: cmd,
-			Env:     subtask.Env,
-		})
+	tasks, err := buildSubtaskInfos(resolved.Project, task, flattenedNames, opts.Args)
+	if err != nil {
+		return 1, err
 	}
 
 	// Resolve hosts - hostOrder preserves priority from config
@@ -233,6 +217,41 @@ func renderParallelResult(result *parallel.Result, logWriter *logs.LogWriter, ta
 		return 1
 	}
 	return 0
+}
+
+// buildSubtaskInfos constructs the TaskInfo list for each flattened subtask name.
+// When forwardTask.ForwardArgs is true and args are provided, they are appended to
+// each subtask's run command. Multi-step subtasks cannot accept forwarded args.
+func buildSubtaskInfos(proj *config.Config, forwardTask *config.TaskConfig, flattenedNames []string, args []string) ([]parallel.TaskInfo, error) {
+	tasks := make([]parallel.TaskInfo, 0, len(flattenedNames))
+	for i, subtaskName := range flattenedNames {
+		subtask, err := config.GetTask(proj, subtaskName)
+		if err != nil {
+			return nil, err
+		}
+
+		cmd := subtask.Run
+		if cmd == "" && len(subtask.Steps) > 0 {
+			cmd = buildStepsCommand(subtask.Steps)
+		}
+
+		if forwardTask.ForwardArgs && len(args) > 0 {
+			if len(subtask.Steps) > 0 {
+				return nil, errors.New(errors.ErrConfig,
+					fmt.Sprintf("subtask '%s' uses steps and cannot accept forwarded args", subtaskName),
+					"remove forward_args from the parent task or convert the subtask to a single run command")
+			}
+			cmd = cmd + " " + strings.Join(args, " ")
+		}
+
+		tasks = append(tasks, parallel.TaskInfo{
+			Name:    subtaskName,
+			Index:   i,
+			Command: cmd,
+			Env:     subtask.Env,
+		})
+	}
+	return tasks, nil
 }
 
 // writeTaskLogs writes task outputs to log files, warning on errors.

--- a/internal/cli/parallel.go
+++ b/internal/cli/parallel.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rileyhilliard/rr/internal/errors"
 	"github.com/rileyhilliard/rr/internal/parallel"
 	"github.com/rileyhilliard/rr/internal/parallel/logs"
+	"github.com/rileyhilliard/rr/internal/util"
 )
 
 // ParallelTaskOptions configures parallel task execution.
@@ -241,7 +242,11 @@ func buildSubtaskInfos(proj *config.Config, forwardTask *config.TaskConfig, flat
 					fmt.Sprintf("subtask '%s' uses steps and cannot accept forwarded args", subtaskName),
 					"remove forward_args from the parent task or convert the subtask to a single run command")
 			}
-			cmd = cmd + " " + strings.Join(args, " ")
+			quoted := make([]string, len(args))
+			for i, a := range args {
+				quoted[i] = util.ShellQuote(a)
+			}
+			cmd = cmd + " " + strings.Join(quoted, " ")
 		}
 
 		tasks = append(tasks, parallel.TaskInfo{

--- a/internal/cli/parallel_test.go
+++ b/internal/cli/parallel_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rileyhilliard/rr/internal/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFilterHostsByTag(t *testing.T) {
@@ -133,4 +134,101 @@ func TestFilterHostsByTag_PreservesHostData(t *testing.T) {
 	assert.Equal(t, "/home/user/project", host.Dir)
 	assert.Equal(t, []string{"target", "other"}, host.Tags)
 	assert.Equal(t, "value", host.Env["KEY"])
+}
+
+// TestParallelTaskOptions_ArgsField verifies the Args field is present
+// and carries through as expected (struct-level coverage for forward_args plumbing).
+func TestParallelTaskOptions_ArgsField(t *testing.T) {
+	opts := ParallelTaskOptions{
+		TaskName: "test-backend",
+		Args:     []string{"-k", "bond", "-v"},
+	}
+	assert.Equal(t, []string{"-k", "bond", "-v"}, opts.Args)
+}
+
+// TestForwardArgs_ConfigFieldPresent verifies the ForwardArgs field is on TaskConfig.
+func TestForwardArgs_ConfigFieldPresent(t *testing.T) {
+	task := config.TaskConfig{
+		Parallel:    []string{"sub-a", "sub-b"},
+		ForwardArgs: true,
+	}
+	assert.True(t, task.ForwardArgs)
+
+	taskDefault := config.TaskConfig{
+		Parallel: []string{"sub-a"},
+	}
+	assert.False(t, taskDefault.ForwardArgs, "ForwardArgs should default to false")
+}
+
+// TestParallelTask_RejectsArgsViaCobra verifies that a parallel task without
+// forward_args rejects extra positional arguments with a descriptive error.
+func TestParallelTask_RejectsArgsViaCobra(t *testing.T) {
+	task := config.TaskConfig{
+		Parallel: []string{"sub"},
+	}
+	cmd := createParallelTaskCommand("my-task", task)
+	cmd.SetArgs([]string{"extra-arg"})
+	execErr := cmd.Execute()
+	require.Error(t, execErr)
+	assert.Contains(t, execErr.Error(), "doesn't accept extra arguments")
+	assert.Contains(t, execErr.Error(), "extra-arg")
+}
+
+// TestBuildSubtaskInfos_ForwardArgsAppended verifies that when forward_args is true
+// extra args are appended to each subtask's run command.
+func TestBuildSubtaskInfos_ForwardArgsAppended(t *testing.T) {
+	proj := &config.Config{
+		Tasks: map[string]config.TaskConfig{
+			"sub-a": {Run: "pytest tests/a"},
+			"sub-b": {Run: "pytest tests/b"},
+		},
+	}
+	parentTask := &config.TaskConfig{
+		Parallel:    []string{"sub-a", "sub-b"},
+		ForwardArgs: true,
+	}
+	args := []string{"-k", "bond", "-v"}
+
+	infos, err := buildSubtaskInfos(proj, parentTask, []string{"sub-a", "sub-b"}, args)
+	require.NoError(t, err)
+	require.Len(t, infos, 2)
+	assert.Equal(t, "pytest tests/a -k bond -v", infos[0].Command)
+	assert.Equal(t, "pytest tests/b -k bond -v", infos[1].Command)
+}
+
+// TestBuildSubtaskInfos_ForwardArgsRejectsStepsSubtask verifies that forward_args
+// produces a clear error when a subtask uses steps rather than a single run command.
+func TestBuildSubtaskInfos_ForwardArgsRejectsStepsSubtask(t *testing.T) {
+	proj := &config.Config{
+		Tasks: map[string]config.TaskConfig{
+			"multi-step": {Steps: []config.TaskStep{{Run: "step1"}, {Run: "step2"}}},
+		},
+	}
+	parentTask := &config.TaskConfig{
+		Parallel:    []string{"multi-step"},
+		ForwardArgs: true,
+	}
+
+	_, err := buildSubtaskInfos(proj, parentTask, []string{"multi-step"}, []string{"-k", "bond"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "uses steps and cannot accept forwarded args")
+}
+
+// TestBuildSubtaskInfos_NoForwardArgsIgnoresArgs verifies that when forward_args is
+// false, extra args are not appended (they should have been rejected earlier by cobra).
+func TestBuildSubtaskInfos_NoForwardArgsIgnoresArgs(t *testing.T) {
+	proj := &config.Config{
+		Tasks: map[string]config.TaskConfig{
+			"sub-a": {Run: "pytest tests/a"},
+		},
+	}
+	parentTask := &config.TaskConfig{
+		Parallel:    []string{"sub-a"},
+		ForwardArgs: false,
+	}
+
+	infos, err := buildSubtaskInfos(proj, parentTask, []string{"sub-a"}, []string{"-k", "bond"})
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "pytest tests/a", infos[0].Command, "args should not be appended when forward_args is false")
 }

--- a/internal/cli/parallel_test.go
+++ b/internal/cli/parallel_test.go
@@ -192,8 +192,8 @@ func TestBuildSubtaskInfos_ForwardArgsAppended(t *testing.T) {
 	infos, err := buildSubtaskInfos(proj, parentTask, []string{"sub-a", "sub-b"}, args)
 	require.NoError(t, err)
 	require.Len(t, infos, 2)
-	assert.Equal(t, "pytest tests/a -k bond -v", infos[0].Command)
-	assert.Equal(t, "pytest tests/b -k bond -v", infos[1].Command)
+	assert.Equal(t, "pytest tests/a '-k' 'bond' '-v'", infos[0].Command)
+	assert.Equal(t, "pytest tests/b '-k' 'bond' '-v'", infos[1].Command)
 }
 
 // TestBuildSubtaskInfos_ForwardArgsRejectsStepsSubtask verifies that forward_args

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -266,6 +266,8 @@ func init() {
 		"human-readable output with spinners and colors (default is structured JSON)")
 	rootCmd.PersistentFlags().BoolVarP(&machineMode, "machine", "m", false,
 		"machine-readable JSON output (default behavior, kept for compatibility)")
+	rootCmd.PersistentFlags().BoolVar(&suppressPhases, "no-phases", false,
+		"suppress intermediate phase events on stderr (connect, sync, exec); final result event is still emitted")
 
 	// Set up styled warning handler for sshutil package
 	sshutil.WarningHandler = ui.PrintWarning

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -18,6 +19,7 @@ import (
 	"github.com/rileyhilliard/rr/internal/parallel"
 	"github.com/rileyhilliard/rr/internal/parallel/logs"
 	"github.com/rileyhilliard/rr/internal/ui"
+	"github.com/rileyhilliard/rr/internal/util"
 )
 
 // RunOptions holds options for the run command.
@@ -31,6 +33,7 @@ type RunOptions struct {
 	SkipRequirements bool          // If true, skip requirement checks
 	DryRun           bool          // If true, show what would be done without doing it
 	WorkingDir       string        // Override local working directory
+	RemoteCWD        string        // Subdirectory to cd into on remote before running (relative to host.Dir)
 	Quiet            bool          // If true, minimize output (no individual connection attempts)
 	Local            bool          // If true, force local execution (skip remote hosts)
 	Pull             []string      // Patterns to pull from remote after command completes
@@ -80,6 +83,12 @@ func Run(opts RunOptions) (int, error) {
 		cmd := opts.Command
 		if len(wf.Resolved.Project.Defaults.Setup) > 0 {
 			cmd = strings.Join(wf.Resolved.Project.Defaults.Setup, " && ") + " && " + cmd
+		}
+		// --cwd prepends a cd into a subdirectory of the remote project root
+		if opts.RemoteCWD != "" {
+			remoteProjectDir := config.ExpandRemote(wf.Conn.Host.Dir)
+			subdir := util.ShellQuotePreserveTilde(filepath.Join(remoteProjectDir, opts.RemoteCWD))
+			cmd = fmt.Sprintf("cd %s && %s", subdir, cmd)
 		}
 		fullCmd := exec.BuildRemoteCommand(cmd, &wf.Conn.Host)
 		exitCode, err = wf.Conn.Client.ExecStreamContext(wf.Context(), fullCmd, streamHandler.Stdout(), streamHandler.Stderr())
@@ -285,7 +294,7 @@ func mapProbeErrorToStatus(err error) ui.ConnectionStatus {
 }
 
 // runCommand is the actual implementation called by the cobra command.
-func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag, skipRequirementsFlag bool, repeatCount int, pullPatterns []string, pullDest string) error {
+func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, localFlag, skipRequirementsFlag bool, repeatCount int, pullPatterns []string, pullDest, remoteCWD string) error {
 	if len(args) == 0 {
 		return errors.New(errors.ErrExec,
 			"What should I run?",
@@ -322,6 +331,7 @@ func runCommand(args []string, hostFlag, tagFlag, probeTimeoutFlag string, local
 		Local:            localFlag,
 		Pull:             pullPatterns,
 		PullDest:         pullDest,
+		RemoteCWD:        remoteCWD,
 	})
 
 	if err != nil {

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
-	"path/filepath"
+	"path"
 	"strings"
 	"syscall"
 	"time"
@@ -88,7 +88,7 @@ func Run(opts RunOptions) (int, error) {
 		// Reject paths that escape the project root via ../ traversal.
 		if opts.RemoteCWD != "" {
 			remoteProjectDir := config.ExpandRemote(wf.Conn.Host.Dir)
-			resolved := filepath.Join(remoteProjectDir, opts.RemoteCWD)
+			resolved := path.Join(remoteProjectDir, opts.RemoteCWD)
 			if !strings.HasPrefix(resolved+"/", remoteProjectDir+"/") {
 				return 1, errors.New(errors.ErrConfig,
 					fmt.Sprintf("--cwd '%s' escapes the remote project root", opts.RemoteCWD),

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -84,10 +84,17 @@ func Run(opts RunOptions) (int, error) {
 		if len(wf.Resolved.Project.Defaults.Setup) > 0 {
 			cmd = strings.Join(wf.Resolved.Project.Defaults.Setup, " && ") + " && " + cmd
 		}
-		// --cwd prepends a cd into a subdirectory of the remote project root
+		// --cwd prepends a cd into a subdirectory of the remote project root.
+		// Reject paths that escape the project root via ../ traversal.
 		if opts.RemoteCWD != "" {
 			remoteProjectDir := config.ExpandRemote(wf.Conn.Host.Dir)
-			subdir := util.ShellQuotePreserveTilde(filepath.Join(remoteProjectDir, opts.RemoteCWD))
+			resolved := filepath.Join(remoteProjectDir, opts.RemoteCWD)
+			if !strings.HasPrefix(resolved+"/", remoteProjectDir+"/") {
+				return 1, errors.New(errors.ErrConfig,
+					fmt.Sprintf("--cwd '%s' escapes the remote project root", opts.RemoteCWD),
+					"use a path relative to the project root without '..' components")
+			}
+			subdir := util.ShellQuotePreserveTilde(resolved)
 			cmd = fmt.Sprintf("cd %s && %s", subdir, cmd)
 		}
 		fullCmd := exec.BuildRemoteCommand(cmd, &wf.Conn.Host)

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -125,13 +125,13 @@ func TestRunOptions_WithValues(t *testing.T) {
 }
 
 func TestRunCommand_NoArgs(t *testing.T) {
-	err := runCommand([]string{}, "", "", "", false, false, 0, nil, "")
+	err := runCommand([]string{}, "", "", "", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
 
 func TestRunCommand_InvalidProbeTimeout(t *testing.T) {
-	err := runCommand([]string{"echo hello"}, "", "", "invalid-timeout", false, false, 0, nil, "")
+	err := runCommand([]string{"echo hello"}, "", "", "invalid-timeout", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "doesn't look like a valid timeout")
 }
@@ -150,7 +150,7 @@ func TestRunCommand_JoinsArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined into single command
-	err = runCommand([]string{"make", "test"}, "", "", "", false, false, 0, nil, "")
+	err = runCommand([]string{"make", "test"}, "", "", "", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	// Should fail on no hosts configured
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -168,20 +168,20 @@ func TestRunCommand_ValidProbeTimeout(t *testing.T) {
 	require.NoError(t, err)
 
 	// Valid probe timeout should not fail on parsing
-	err = runCommand([]string{"echo"}, "", "", "5s", false, false, 0, nil, "")
+	err = runCommand([]string{"echo"}, "", "", "5s", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	// Should fail on no hosts configured, not on probe timeout
 	assert.NotContains(t, err.Error(), "timeout")
 }
 
 func TestExecCommand_NoArgs(t *testing.T) {
-	err := execCommand([]string{}, "", "", "", false, false, nil, "")
+	err := execCommand([]string{}, "", "", "", false, false, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
 
 func TestExecCommand_InvalidProbeTimeout(t *testing.T) {
-	err := execCommand([]string{"ls"}, "", "", "bad-duration", false, false, nil, "")
+	err := execCommand([]string{"ls"}, "", "", "bad-duration", false, false, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "doesn't look like a valid timeout")
 }
@@ -198,7 +198,7 @@ func TestExecCommand_JoinsArgs(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined
-	err = execCommand([]string{"ls", "-la"}, "", "", "", false, false, nil, "")
+	err = execCommand([]string{"ls", "-la"}, "", "", "", false, false, nil, "", "")
 	require.Error(t, err)
 	// Should fail on no hosts configured
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -227,7 +227,7 @@ func TestExecCommand_ValidProbeTimeoutFormats(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := execCommand([]string{"ls"}, "", "", tt.timeout, false, false, nil, "")
+			err := execCommand([]string{"ls"}, "", "", tt.timeout, false, false, nil, "", "")
 			// Should fail with config error, not parse error
 			if err != nil {
 				assert.NotContains(t, err.Error(), "doesn't look like a valid timeout",
@@ -470,7 +470,7 @@ func TestRunOptions_ZeroValues(t *testing.T) {
 }
 
 func TestRunCommand_EmptyArgs(t *testing.T) {
-	err := runCommand([]string{}, "", "", "", false, false, 0, nil, "")
+	err := runCommand([]string{}, "", "", "", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "What should I run?")
 }
@@ -487,7 +487,7 @@ func TestRunCommand_MultipleArgsJoined(t *testing.T) {
 	require.NoError(t, err)
 
 	// Multiple args should be joined with spaces
-	err = runCommand([]string{"make", "test", "-v"}, "", "", "", false, false, 0, nil, "")
+	err = runCommand([]string{"make", "test", "-v"}, "", "", "", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	// Fails on no hosts configured, but args were processed
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -504,7 +504,7 @@ func TestRunCommand_WithHostAndTag(t *testing.T) {
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	err = runCommand([]string{"echo"}, "myhost", "mytag", "", false, false, 0, nil, "")
+	err = runCommand([]string{"echo"}, "myhost", "mytag", "", false, false, 0, nil, "", "")
 	require.Error(t, err)
 	// Should fail on no hosts configured, flags were accepted
 	assert.Contains(t, err.Error(), "No hosts configured")
@@ -521,7 +521,7 @@ func TestExecCommand_MultipleArgsJoined(t *testing.T) {
 	err := os.Chdir(tmpDir)
 	require.NoError(t, err)
 
-	err = execCommand([]string{"ls", "-la", "/tmp"}, "", "", "", false, false, nil, "")
+	err = execCommand([]string{"ls", "-la", "/tmp"}, "", "", "", false, false, nil, "", "")
 	require.Error(t, err)
 	// Fails on no hosts configured, but args were processed
 	assert.Contains(t, err.Error(), "No hosts configured")

--- a/internal/cli/run_test.go
+++ b/internal/cli/run_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path"
 	"strings"
 	"testing"
 	"time"
@@ -734,6 +735,33 @@ func TestPull_WithTagFlag(t *testing.T) {
 		Tag:      "gpu",
 	})
 	require.Error(t, err)
+}
+
+// TestRemoteCWD_TraversalGuard verifies the path-prefix check that prevents
+// --cwd from escaping the remote project root via ../ sequences.
+// Mirrors the exact filepath.Join + strings.HasPrefix logic in run.go.
+func TestRemoteCWD_TraversalGuard(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteRoot string
+		cwd        string
+		wantEscape bool
+	}{
+		{"safe subdir", "/home/user/project", "backend", false},
+		{"nested subdir", "/home/user/project", "backend/api", false},
+		{"dotdot escapes", "/home/user/project", "../other", true},
+		{"dotdot full escape", "/home/user/project", "../../etc", true},
+		{"dotdot then descend into sibling", "/home/user/project", "../project2/src", true},
+		{"dotdot then back to same root", "/home/user/project", "../project/backend", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved := path.Join(tt.remoteRoot, tt.cwd)
+			escaped := !strings.HasPrefix(resolved+"/", tt.remoteRoot+"/")
+			assert.Equal(t, tt.wantEscape, escaped, "cwd=%q resolved to %q", tt.cwd, resolved)
+		})
+	}
 }
 
 func TestPull_DryRunMode(t *testing.T) {

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -697,11 +697,22 @@ func createParallelTaskCommand(name string, task config.TaskConfig) *cobra.Comma
 	var noLogsFlag bool
 	var dryRunFlag bool
 
+	useStr := name
+	if task.ForwardArgs {
+		useStr = name + " [args...]"
+	}
+
 	cmd := &cobra.Command{
-		Use:   name,
+		Use:   useStr,
 		Short: task.Description,
 		Long:  buildParallelTaskLongDescription(name, task),
+		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 && !task.ForwardArgs {
+				return errors.New(errors.ErrConfig,
+					fmt.Sprintf("parallel task '%s' doesn't accept extra arguments (got: %s)", name, strings.Join(args, " ")),
+					fmt.Sprintf("use 'rr run \"<command> %s\"' for ad-hoc runs with custom args", strings.Join(args, " ")))
+			}
 			return runParallelTaskCommand(name, ParallelTaskOptions{
 				TaskName:    name,
 				Host:        hostFlag,
@@ -714,6 +725,7 @@ func createParallelTaskCommand(name string, task config.TaskConfig) *cobra.Comma
 				NoLogs:      noLogsFlag,
 				DryRun:      dryRunFlag,
 				Local:       localFlag,
+				Args:        args,
 			})
 		},
 	}

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -386,3 +386,77 @@ func TestRenderTaskSummary_MultiStepFirstStepFails(t *testing.T) {
 	assert.Contains(t, output, "step 'setup'")
 	assert.Contains(t, output, ui.SymbolFail)
 }
+
+func TestCreateParallelTaskCommand_RejectsExtraArgs(t *testing.T) {
+	task := config.TaskConfig{
+		Description: "Run tests in parallel",
+		Parallel:    []string{"subtask-a", "subtask-b"},
+	}
+
+	cmd := createParallelTaskCommand("test-backend", task)
+
+	// Execute with extra args — should return a helpful error
+	cmd.SetArgs([]string{"extra", "arg"})
+	err := cmd.Execute()
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "parallel task 'test-backend' doesn't accept extra arguments")
+	assert.Contains(t, err.Error(), "extra arg")
+}
+
+func TestCreateParallelTaskCommand_AcceptsNoArgs(t *testing.T) {
+	task := config.TaskConfig{
+		Description: "Run tests in parallel",
+		Parallel:    []string{"subtask-a"},
+	}
+
+	cmd := createParallelTaskCommand("test-backend", task)
+
+	// RunE will fail because there's no real config, but the error should NOT
+	// be about argument rejection — args were accepted, config loading failed.
+	cmd.SetArgs([]string{})
+	err := cmd.Execute()
+
+	// If there's an error it should be about config/hosts, not about argument rejection
+	if err != nil {
+		assert.NotContains(t, err.Error(), "doesn't accept extra arguments")
+	}
+}
+
+func TestCreateParallelTaskCommand_ForwardArgsAcceptsArgs(t *testing.T) {
+	task := config.TaskConfig{
+		Description: "Run tests in parallel",
+		Parallel:    []string{"subtask-a"},
+		ForwardArgs: true,
+	}
+
+	cmd := createParallelTaskCommand("test-backend", task)
+
+	// With forward_args, extra args should NOT produce the arg-rejection error.
+	// RunE may fail due to no config, but not due to arg rejection.
+	cmd.SetArgs([]string{"-k", "bond"})
+	err := cmd.Execute()
+
+	if err != nil {
+		assert.NotContains(t, err.Error(), "doesn't accept extra arguments",
+			"forward_args task should accept extra arguments")
+	}
+}
+
+func TestCreateParallelTaskCommand_ForwardArgsUseLine(t *testing.T) {
+	taskWithForward := config.TaskConfig{
+		Parallel:    []string{"sub"},
+		ForwardArgs: true,
+	}
+	taskWithoutForward := config.TaskConfig{
+		Parallel: []string{"sub"},
+	}
+
+	cmdWith := createParallelTaskCommand("test", taskWithForward)
+	cmdWithout := createParallelTaskCommand("test", taskWithoutForward)
+
+	assert.Contains(t, cmdWith.Use, "[args...]",
+		"forward_args task should show [args...] in Use string")
+	assert.NotContains(t, cmdWithout.Use, "[args...]",
+		"regular parallel task should not show [args...] in Use string")
+}

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -463,8 +463,17 @@ func lockPhase(ctx *WorkflowContext, opts WorkflowOptions) error {
 	reporter := ctx.GetReporter()
 	reporter.PhaseStart("lock")
 
+	stealWarn := func(msg string) {
+		WritePhaseEvent(PhaseEvent{
+			Type:    "phase",
+			Phase:   "lock",
+			Status:  "warn",
+			Details: map[string]interface{}{"message": msg},
+		})
+	}
+
 	var err error
-	ctx.Lock, err = lock.Acquire(ctx.Conn, lockCfg, opts.Command)
+	ctx.Lock, err = lock.Acquire(ctx.Conn, lockCfg, opts.Command, lock.WithWarnFunc(stealWarn))
 	if err != nil {
 		reporter.PhaseFailed("lock", err)
 		return err

--- a/internal/cli/workflow.go
+++ b/internal/cli/workflow.go
@@ -346,7 +346,18 @@ func syncStructured(ctx *WorkflowContext, syncStart time.Time) error {
 
 	syncCfg := resolveSyncConfig(ctx)
 
-	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations); err != nil {
+	invalidationNotify := func(dir, lockfile string) {
+		WritePhaseEvent(PhaseEvent{
+			Type:   "phase",
+			Phase:  "sync",
+			Status: "invalidated",
+			Details: map[string]interface{}{
+				"dir":      dir,
+				"lockfile": lockfile,
+			},
+		})
+	}
+	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations, invalidationNotify); err != nil {
 		reporter.PhaseFailed("sync", err)
 		return err
 	}
@@ -374,7 +385,8 @@ func syncWithProgress(ctx *WorkflowContext, syncStart time.Time) error {
 	syncCfg := resolveSyncConfig(ctx)
 
 	// Delete stale remote directories when lockfiles have changed before syncing.
-	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations); err != nil {
+	// Pretty mode: nil notify falls back to fmt.Printf in sync package.
+	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations, nil); err != nil {
 		return err
 	}
 
@@ -399,7 +411,8 @@ func syncQuiet(ctx *WorkflowContext, syncStart time.Time) error {
 	syncCfg := resolveSyncConfig(ctx)
 
 	// Delete stale remote directories when lockfiles have changed before syncing.
-	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations); err != nil {
+	// Pretty mode: nil notify falls back to fmt.Printf in sync package.
+	if err := rrsync.InvalidateStaleDirectories(ctx.Conn, ctx.WorkDir, syncCfg.Invalidations, nil); err != nil {
 		return err
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -478,7 +478,7 @@ func setDurationDefaults(v *viper.Viper) {
 	// Set defaults that will be merged
 	v.SetDefault("lock.enabled", true)
 	v.SetDefault("lock.timeout", "5m")
-	v.SetDefault("lock.stale", "3m")
+	v.SetDefault("lock.stale", "90s")
 	v.SetDefault("lock.dir", "/tmp/rr-locks")
 	v.SetDefault("output.color", "auto")
 	v.SetDefault("output.format", "auto")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -208,6 +208,11 @@ type TaskConfig struct {
 	// Simple: pull: [coverage.xml, htmlcov/]
 	// With destinations: pull: [{src: dist/*.whl, dest: ./artifacts/}]
 	Pull []PullItem `yaml:"pull,omitempty" mapstructure:"pull"`
+
+	// ForwardArgs appends extra CLI arguments to each subtask's run command.
+	// Only valid for parallel tasks where all subtasks use a single run command (not steps).
+	// Enables: rr test-backend -k bond  (forwards "-k bond" to each subtask)
+	ForwardArgs bool `yaml:"forward_args" mapstructure:"forward_args"`
 }
 
 // DependencyItem represents a single dependency which can be either

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -2,6 +2,7 @@ package lock
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -134,9 +135,11 @@ func Acquire(conn *host.Connection, cfg config.LockConfig, command string, opts 
 		// Check for stale lock
 		if isLockStale(conn.Client, infoFile, cfg.Stale) {
 			log.Debug("detected stale lock, attempting removal")
+			holder := readLockHolder(conn.Client, infoFile)
 			// Remove stale lock
 			if err := forceRemove(conn.Client, lockDir); err == nil {
-				log.Debug("stale lock removed successfully")
+				log.Warn("stale lock on %s stolen (holder: %s)", conn.Name, holder)
+				fmt.Fprintf(os.Stderr, "Warning: stealing stale lock on %s (holder: %s)\n", conn.Name, holder)
 				// Stale lock removed, try again immediately
 				continue
 			}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -20,13 +20,23 @@ import (
 type AcquireOption func(*acquireOptions)
 
 type acquireOptions struct {
-	logger logger.Logger
+	logger   logger.Logger
+	warnFunc func(msg string)
 }
 
 // WithLogger sets the logger for lock operations.
 func WithLogger(l logger.Logger) AcquireOption {
 	return func(o *acquireOptions) {
 		o.logger = l
+	}
+}
+
+// WithWarnFunc sets a callback for user-visible warnings during lock acquisition
+// (e.g. stale lock stolen). Callers in structured-output mode should emit a
+// phase event; callers in pretty mode can write to stderr directly.
+func WithWarnFunc(fn func(msg string)) AcquireOption {
+	return func(o *acquireOptions) {
+		o.warnFunc = fn
 	}
 }
 
@@ -139,7 +149,12 @@ func Acquire(conn *host.Connection, cfg config.LockConfig, command string, opts 
 			// Remove stale lock
 			if err := forceRemove(conn.Client, lockDir); err == nil {
 				log.Warn("stale lock on %s stolen (holder: %s)", conn.Name, holder)
-				fmt.Fprintf(os.Stderr, "Warning: stealing stale lock on %s (holder: %s)\n", conn.Name, holder)
+				msg := fmt.Sprintf("Warning: stealing stale lock on %s (holder: %s)", conn.Name, holder)
+				if options.warnFunc != nil {
+					options.warnFunc(msg)
+				} else {
+					fmt.Fprintln(os.Stderr, msg)
+				}
 				// Stale lock removed, try again immediately
 				continue
 			}

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -314,7 +314,12 @@ func handleRsyncError(err error, hostName string, stderrOutput string) error {
 // preserves it.
 //
 // Skip silently if conn is nil, local, or invalidations is empty.
-func InvalidateStaleDirectories(conn *host.Connection, localDir string, invalidations []config.LockfileInvalidation) error {
+// InvalidationNotifyFunc is called when a stale directory is about to be removed.
+// dir is the relative path (e.g. "node_modules/"), lockfile is the triggering lockfile.
+// When nil, a plain fmt.Printf line is written to stdout.
+type InvalidationNotifyFunc func(dir, lockfile string)
+
+func InvalidateStaleDirectories(conn *host.Connection, localDir string, invalidations []config.LockfileInvalidation, notify InvalidationNotifyFunc) error {
 	if conn == nil || conn.IsLocal || conn.Client == nil || len(invalidations) == 0 {
 		return nil
 	}
@@ -365,7 +370,11 @@ func InvalidateStaleDirectories(conn *host.Connection, localDir string, invalida
 			// If local lockfile is newer than remote dir (or remote dir is missing),
 			// delete the remote directory so the package manager reinstalls
 			if localMtime > remoteMtime {
-				fmt.Printf("Invalidating stale %s (%s changed)\n", dir, inv.Lockfile)
+				if notify != nil {
+					notify(dir, inv.Lockfile)
+				} else {
+					fmt.Printf("Invalidating stale %s (%s changed)\n", dir, inv.Lockfile)
+				}
 
 				rmCmd := fmt.Sprintf("rm -rf %s", util.ShellQuotePreserveTilde(remotePath))
 				_, rmStderr, rmExit, rmErr := conn.Client.Exec(rmCmd)

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -915,13 +915,13 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 	}
 
 	t.Run("skips nil connection", func(t *testing.T) {
-		err := InvalidateStaleDirectories(nil, localDir, invalidations)
+		err := InvalidateStaleDirectories(nil, localDir, invalidations, nil)
 		assert.NoError(t, err)
 	})
 
 	t.Run("skips local connection", func(t *testing.T) {
 		conn := &host.Connection{IsLocal: true}
-		err := InvalidateStaleDirectories(conn, localDir, invalidations)
+		err := InvalidateStaleDirectories(conn, localDir, invalidations, nil)
 		assert.NoError(t, err)
 	})
 
@@ -933,7 +933,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Client: mock,
 			Host:   config.Host{Dir: "~/rr/myapp"},
 		}
-		err := InvalidateStaleDirectories(conn, localDir, nil)
+		err := InvalidateStaleDirectories(conn, localDir, nil, nil)
 		assert.NoError(t, err)
 	})
 
@@ -946,7 +946,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Host:   config.Host{Dir: "~/rr/myapp"},
 		}
 		// No bun.lock in localDir - should be a no-op
-		err := InvalidateStaleDirectories(conn, localDir, invalidations)
+		err := InvalidateStaleDirectories(conn, localDir, invalidations, nil)
 		assert.NoError(t, err)
 	})
 
@@ -975,7 +975,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Host:   config.Host{Dir: "/root/rr/myapp"},
 		}
 
-		err := InvalidateStaleDirectories(conn, localDir, invalidations)
+		err := InvalidateStaleDirectories(conn, localDir, invalidations, nil)
 		assert.NoError(t, err)
 	})
 
@@ -1017,7 +1017,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Host:   config.Host{Dir: "/root/rr/myapp"},
 		}
 
-		err = InvalidateStaleDirectories(conn, localDir, invalidations)
+		err = InvalidateStaleDirectories(conn, localDir, invalidations, nil)
 		assert.NoError(t, err)
 		// We can't easily assert rm was NOT called with MockClient's current API,
 		// but the function should succeed with no error.
@@ -1046,7 +1046,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Host:   config.Host{Dir: "/root/rr/myapp"},
 		}
 
-		err := InvalidateStaleDirectories(conn, localDir, multiDirInvalidations)
+		err := InvalidateStaleDirectories(conn, localDir, multiDirInvalidations, nil)
 		assert.NoError(t, err)
 	})
 
@@ -1066,7 +1066,7 @@ func TestInvalidateStaleDirectories(t *testing.T) {
 			Host:   config.Host{Dir: "/root/rr/myapp"},
 		}
 
-		err := InvalidateStaleDirectories(conn, localDir, emptyDirsInvalidations)
+		err := InvalidateStaleDirectories(conn, localDir, emptyDirsInvalidations, nil)
 		assert.NoError(t, err)
 	})
 }

--- a/internal/ui/colors.go
+++ b/internal/ui/colors.go
@@ -14,6 +14,12 @@ func DisableColors() {
 	lipgloss.SetColorProfile(termenv.Ascii)
 }
 
+// EnableColors re-enables color output by detecting the terminal's color profile.
+// Used by commands like 'monitor' that are always interactive TUI.
+func EnableColors() {
+	lipgloss.SetColorProfile(termenv.ColorProfile())
+}
+
 // Electric Synthwave color palette - Gen Z dopamine-inducing neons
 // Primary accent colors
 const (

--- a/plugins/rr/skills/rr/SKILL.md
+++ b/plugins/rr/skills/rr/SKILL.md
@@ -122,6 +122,10 @@ Tasks come in three types. The type determines whether extra args work:
 
 **When you need custom args on a parallel task, bypass it:**
 ```bash
+# Preferred: use --cwd for subdirectory execution (path-traversal safe)
+rr run --cwd backend "uv run pytest tests/bond/ -v"
+
+# Fallback: manual cd pattern (avoid — quoting errors are common)
 rr run "cd backend && uv run pytest tests/bond/ -v"
 ```
 

--- a/plugins/rr/skills/rr/SKILL.md
+++ b/plugins/rr/skills/rr/SKILL.md
@@ -110,6 +110,61 @@ Extra arguments append to single-command tasks: `rr test -k "test_login"`
 
 **See [tasks.md](reference/tasks.md) for parallel tasks, multi-step tasks, and advanced configuration.**
 
+## Task Types and Arguments
+
+Tasks come in three types. The type determines whether extra args work:
+
+| Type | Config field | Accepts args? | Example |
+|------|-------------|---------------|---------|
+| Single-command | `run:` | YES | `rr test -k "test_foo"` |
+| Multi-step | `steps:` | NO (errors) | `rr deploy` |
+| Parallel | `parallel:` | NO unless `forward_args: true` | `rr test-all` |
+
+**When you need custom args on a parallel task, bypass it:**
+```bash
+rr run "cd backend && uv run pytest tests/bond/ -v"
+```
+
+To check which type a task is: `rr <task> --help`
+
+To forward args to all subtasks in a parallel task, set `forward_args: true` in the task config:
+```yaml
+tasks:
+  test-backend:
+    parallel: [test-backend-api, test-backend-services]
+    forward_args: true   # rr test-backend -k bond works
+```
+
+## Choosing the Right Command
+
+```
+Need to run something remotely?
+├── Named task exists? → rr <task>
+│   ├── Single-command task → rr <task> <args>   (args forwarded)
+│   ├── Parallel task (forward_args: true) → rr <task> <args>
+│   └── Parallel task (default) → rr run "cd <dir> && <cmd> <args>"
+├── No task, files may have changed → rr run "<command>"   (syncs first)
+└── Files already synced → rr exec "<command>"   (faster, skips sync)
+```
+
+**Never nest rr inside rr exec** — rr may not be installed on the remote:
+```bash
+# Wrong:  rr exec "rr sync && pytest"
+# Right:  rr run "pytest"
+```
+
+## Reading rr Output
+
+rr sends phase events (connect, sync, exec) to stderr and command output to stdout.
+
+```bash
+rr test-opendata 2>/dev/null         # suppress all phase events
+rr test-opendata --no-phases         # suppress intermediate events, keep final result JSON
+rr test-opendata 2>&1                # capture everything (mixes phase JSON into output stream)
+```
+
+The final result is always a JSON line on stderr with `"type":"result"` containing exit code, host, and duration.
+
 ## Remote Environment Bootstrap
 
 Declare required tools with `require:` - rr verifies they exist before running commands:
@@ -281,6 +336,11 @@ Missing tools trigger actionable error messages. Tools with built-in installers 
 | "command not found" | Add `setup_commands` or check `require` config |
 | Sync slow | Add large dirs to `sync.exclude` |
 | Lock stuck | `rr unlock` |
+| Lock timeout after crash or cancel | `rr unlock --all` — stale locks from sessions that didn't exit cleanly |
+
+## Self-Documentation
+
+When you're unsure about a task's type, subtasks, or flags, run `rr <task> --help` before executing it. The help output shows whether the task is parallel (and lists subtasks), what flags it accepts, and whether it takes extra arguments. This is faster than reading `.rr.yaml` and avoids the silent-arg-drop problem.
 
 **See [troubleshooting.md](reference/troubleshooting.md) for detailed diagnostics.**
 


### PR DESCRIPTION
## Summary

- Addresses the June 2025 agent friction post-mortem (30 sessions analyzed, 3-15 min waste per session)
- Followed by three security/correctness fixes from post-commit code review

## Changes

### Agent friction fixes (b171d9e)
- **Parallel task arg errors**: extra args on parallel tasks now fail with a helpful message pointing to `rr run` instead of silently dropping
- **`--no-phases` flag**: suppress intermediate phase JSON on stderr (connect/sync/exec) while keeping the final result event — agents capturing command output no longer have to strip phase noise
- **`--cwd` flag**: `rr run --cwd backend "pytest"` instead of error-prone `rr run "cd backend && pytest"` quoting pattern
- **`forward_args`**: parallel task config option to append CLI args to each subtask's run command — `rr test-backend -k bond` now works
- **Stale lock visibility**: lock steal now emits a visible warning instead of silent debug log; default stale threshold reduced 3m → 90s
- **Structured invalidation events**: stale-dir invalidation messages now emit as JSON phase events in machine mode instead of `fmt.Printf`
- **SKILL.md updated**: task type table, command decision tree, output guide, lock troubleshooting

### Code review fixes (9cdf61d)
- **Path traversal guard on `--cwd`**: `filepath.Join` normalizes `../` — added `strings.HasPrefix` check to reject `--cwd` values that escape the remote project root
- **Raw stderr in machine mode**: stale lock steal warning used `fmt.Fprintf(os.Stderr)` which emits unstructured text alongside JSON lines. Moved to a `WithWarnFunc` option (same callback pattern as sync's `InvalidationNotifyFunc`) so structured-mode callers can emit a phase event instead
- **forward_args injection**: forwarded args were concatenated unquoted into the remote command string. Shell-quote each arg via `util.ShellQuote` before joining

## Test plan
- [ ] `rr test-backend extra-arg` returns helpful error about not accepting extra arguments
- [ ] `rr run --no-phases "echo hi"` produces no phase JSON on stderr, only result event
- [ ] `rr run --cwd ../../etc "cat passwd"` is rejected with a clear error
- [ ] `rr run --cwd backend "pwd"` executes in the backend subdirectory
- [ ] All 27 packages pass (`go test ./...`)
- [ ] Lint clean (`golangci-lint run`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--cwd` to `rr run` and `rr exec` for remote working-directory overrides
  * Added `--no-phases` to suppress intermediate phase events
  * Added `forward_args` to allow parallel tasks to accept and forward extra CLI args
  * Restored color output in the interactive TUI when colors are enabled
* **Bug Fixes**
  * Default stale lock timeout changed from 3m to 90s
* **Documentation**
  * Expanded task/argument invocation guidance and troubleshooting
* **Tests**
  * Added coverage for remote CWD traversal protection, phase suppression, and forwarded-args behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->