### PR TITLE
docs: update changelog for v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2] - 2026-06-24
+
+### Fixed
+
+- **Machine-mode parallel results now include failure details** - Previously, failed parallel tasks only emitted pass/fail counts (`{"failed":2,"passed":1,"total":3}`), making it impossible for piped consumers to identify which tests failed. The result event now includes a `failures` array with per-task test names, file locations, and assertion messages (parsed via existing pytest/jest/go formatters), with a raw output tail fallback for non-test commands.
+
 ## [0.22.1] - 2026-06-22
 
 ### Dependencies


### PR DESCRIPTION
## Summary

- Add changelog entry for v0.22.2 release (machine-mode parallel failure details)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine-mode parallel results to include a `failures` array with per-task failure details, such as test names, locations, and assertion messages.
  * Added a fallback to show the raw output tail for non-test commands when structured failure details aren’t available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->