### PR TITLE
ci: pin govulncheck to v1.3.0 to avoid v1.4.0 panic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/go/bin/govulncheck
-          key: govulncheck-${{ runner.os }}-latest
+          key: govulncheck-${{ runner.os }}-v1.3.0
 
       - name: Run govulncheck
         run: |
-          [ -f ~/go/bin/govulncheck ] || go install golang.org/x/vuln/cmd/govulncheck@latest
+          [ -f ~/go/bin/govulncheck ] || go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
           govulncheck ./...
 
   integration:


### PR DESCRIPTION
## Summary

- govulncheck v1.4.0 panics with `ForEachElement called on type containing *types.TypeParam` due to a bug in its dependency `golang.org/x/tools v0.46.0`
- Pins to v1.3.0 (last known-good version) and updates the cache key to bust the stale binary

## Test plan

- [x] CI on this PR should pass with the pinned version