### PR TITLE
fix(sync): translate .gitignore negation into rsync filter rules correctly

### DIFF
--- a/FEEDBACK.md
+++ b/FEEDBACK.md
@@ -1,0 +1,219 @@
+# Agent Compatibility Feedback
+
+Real-world friction encountered using rr with Claude Code (AI coding agent) during a multi-package test coverage task on the OpenData project. Each issue below includes enough context for a fixing agent to understand the problem and implement the solution without additional investigation.
+
+---
+
+## Issue 1: `rr run` should default to structured (agent-friendly) output
+
+### Problem
+
+rr's primary consumers are increasingly AI agents (Claude Code, Cursor, Copilot Workspace) and CI systems, not humans watching terminals. But `rr run` defaults to human-oriented output: spinners, colored progress bars, lipgloss-styled dividers, and inline rsync progress updates. Agents can't reliably parse this output to determine:
+
+- When sync finished and command execution started
+- When command execution completed
+- What the exit code was
+- Which host ran the command
+
+The existing `--machine` / `-m` flag has a proper `JSONEnvelope` structure (defined in `internal/cli/json.go`) but is only implemented for metadata commands (`tasks`, `host list`, `doctor`, `status`). The `run` and `exec` commands always use `output.NewStreamHandler` with lipgloss-decorated output regardless of flags.
+
+### Current behavior
+
+```
+# What rr run outputs today (human-friendly, agent-hostile):
+[spinner] Connecting to m4-mini...
+[spinner] Syncing files...
+  1,234 files  45.2MB  100%
+─────────────────────────────────────────────
+$ pytest -v
+... (test output interleaved with decorations) ...
+───────────
+✓ Completed on m4-mini (12.3s total, 10.1s exec)
+```
+
+An agent sees this as undifferentiated text. It cannot reliably distinguish rr's chrome from the actual command output without fragile regex parsing.
+
+### Desired behavior
+
+**rr should be agent-first.** Structured output should be the DEFAULT. Human-readable decorated output should be the opt-in mode (via `--pretty` or `--human` flag, or auto-detected when stdout is a TTY).
+
+Default output (no flags, stdout is not a TTY):
+```json
+{"phase": "sync", "status": "started", "host": "m4-mini"}
+{"phase": "sync", "status": "complete", "files": 1234, "bytes": 47421440, "duration_ms": 2100}
+{"phase": "exec", "status": "started", "command": "pytest -v", "host": "m4-mini"}
+```
+Then the raw command stdout/stderr streams through undecorated, followed by:
+```json
+{"phase": "exec", "status": "complete", "exit_code": 0, "duration_ms": 10100}
+{"result": {"success": true, "exit_code": 0, "host": "m4-mini", "total_duration_ms": 12300, "sync_duration_ms": 2100, "exec_duration_ms": 10100}}
+```
+
+When stdout IS a TTY (human at terminal), show the current pretty output with spinners and colors.
+
+### Implementation guidance
+
+**Key files:**
+- `internal/cli/run.go` - The `Run()` function (line 42) is the main workflow. Currently always creates `output.NewStreamHandler(os.Stdout, os.Stderr)` at line 69.
+- `internal/cli/json.go` - Already has `JSONEnvelope`, `WriteJSONSuccess`, `WriteJSONError`. Extend with phase-level events.
+- `internal/config/types.go` - `OutputConfig` (line 364) has `Format`, `Color`, `Verbosity` fields. Add a mode concept here.
+
+**Approach:**
+1. Auto-detect: if stdout is a TTY, use pretty mode. If not (piped, redirected, or agent), use structured mode.
+2. Allow override: `--pretty` forces human mode, `--machine`/`-m` forces structured mode regardless of TTY detection.
+3. In structured mode, the `Run()` function should:
+   - Emit JSON phase events to stderr (so they don't mix with command stdout)
+   - Stream command stdout/stderr through unmodified (no spinners, no lipgloss, no dividers)
+   - Emit a final JSON result envelope to stderr after command completes
+4. The existing `MachineMode()` bool in `json.go` already gates behavior in other commands. Wire `run.go` into this same mechanism.
+
+**Exit code contract:** The process exit code should always match the remote command's exit code (already works this way). The JSON envelope is supplementary metadata, not the primary signal.
+
+---
+
+## Issue 2: Auto-exclude `.claude/` in default sync config
+
+### Problem
+
+Claude Code creates a `.claude/` directory in project roots containing:
+- `worktrees/` - Full git worktree checkouts (can be 1-10+ GB)
+- `plans/` - Implementation plans
+- `projects/` - Memory and conversation logs
+- `settings.json` - Agent config
+
+When rr syncs a project to a remote host, it rsyncs this entire directory. In the OpenData project, `.claude/worktrees/` was 3GB, making every `rr run` invocation take minutes for the sync phase instead of seconds.
+
+The worktrees directory is especially problematic because it contains full recursive copies of the project source, including their own `node_modules/`, `.venv/`, etc. Even though those are excluded by name, the worktree itself is a multi-GB git checkout.
+
+### Current default excludes
+
+From `internal/config/types.go` line 452:
+```go
+Exclude: []string{
+    ".git/",
+    ".venv/",
+    "__pycache__/",
+    "*.pyc",
+    "node_modules/",
+    ".mypy_cache/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    ".DS_Store",
+    "*.log",
+},
+```
+
+### Fix
+
+Add `.claude/` to the default exclude list:
+```go
+Exclude: []string{
+    ".git/",
+    ".claude/",
+    ".venv/",
+    "__pycache__/",
+    // ...
+},
+```
+
+Also consider adding other AI agent directories that are becoming common:
+- `.cursor/` (Cursor AI)
+- `.aider/` (Aider)
+- `.copilot/` (GitHub Copilot)
+
+These directories are never needed on remote execution hosts. They contain agent-local state (conversation history, memory, worktrees) that has zero relevance to building/testing code.
+
+**File:** `internal/config/types.go`, the `DefaultConfig()` function around line 452.
+
+---
+
+## Issue 3: Respect `.gitignore` patterns during sync — RESOLVED
+
+### Original problem
+
+The 3GB `.claude/worktrees/` sync issue would never have occurred if rr respected `.gitignore`. That directory is already gitignored (it's not tracked source code), along with most other large directories that shouldn't be synced (`dist/`, `build/`, `.next/`, coverage reports, etc.).
+
+`respect_gitignore: true` (default on) shipped using this issue's originally suggested implementation: `--filter=':- .gitignore'`, letting rsync read and apply `.gitignore` directly.
+
+### Bug found in that implementation
+
+`--filter=':- .gitignore'` has no support for git's `!pattern` negation. Rsync's merge-file syntax only understands a bare `!` on its own line as "clear every rule read so far" — not per-pattern re-inclusion. Any `.gitignore` with the extremely common "ignore broadly, carve out an exception" idiom:
+
+```
+data/
+!frontend/tests/mocks/data/
+```
+
+silently dropped `frontend/tests/mocks/data/` from every `rr sync`, even though `git status`/`git check-ignore` correctly reported it as NOT ignored. This caused real, hard-to-diagnose test failures (missing mock fixtures) on a project using exactly this pattern.
+
+### Fix
+
+`internal/sync/sync.go`'s `gitignoreFilterArgs()` (replacing the bare `--filter=':- .gitignore'` call) now reads `.gitignore` itself and translates it into explicit rsync `+`/`-` filter rules:
+
+- Git resolves a `.gitignore` "last matching pattern wins" (top to bottom); rsync's filter list is "first matching rule wins" — rules are emitted in **reversed** file order to reproduce that.
+- Per `git help gitignore`, "it is not possible to re-include a file if a parent directory of that file is excluded." A `!negation` is only live if every ancestor directory of the negated path independently resolves to not-excluded (a bare directory-unit exclude like `build/` always poisons descendants regardless of order, unless `build/` is itself separately re-included; a wildcard exclude like `build/*` never poisons the directory itself, so a child negation after it works normally). Dead negations are dropped, matching git exactly, instead of emitting an rsync include git would never have honored.
+- Live negations also emit `+` rules for every ancestor directory, since an excluded ancestor stops rsync from descending into it at all regardless of what rules come later.
+
+Covered by `TestBuildArgs_GitignoreTranslation` in `internal/sync/sync_test.go`, including a case verified against real git for a multi-level alternating exclude/re-include chain.
+
+**Edge case still open:** only the repo-root `.gitignore` is read (matching the original `':- .gitignore'` scope for a single project checkout). Nested per-directory `.gitignore` files are not merged — extend `gitignoreFilterArgs` to walk the tree if that's needed later.
+
+---
+
+## Issue 4: Stale locks from interrupted agent sessions
+
+### Problem
+
+When an AI agent's session is interrupted (context window exhausted, user cancels, process killed, or Claude Code compacts its conversation), any in-progress `rr` command dies without releasing its lock. The next `rr` invocation then hits "Lock timeout" and fails, requiring manual `rr unlock`.
+
+This happens frequently with AI agents because:
+- Context windows get exhausted mid-command
+- Users cancel and restart conversations
+- Agent processes timeout
+- The agent has no way to register cleanup handlers for external processes
+
+Current lock config (from `DefaultConfig()`):
+```go
+Lock: LockConfig{
+    Enabled:     true,
+    Timeout:     5 * time.Minute,
+    WaitTimeout: 1 * time.Minute,
+    Stale:       10 * time.Minute,  // <-- locks are stale after 10 minutes
+    Dir:         "/tmp/rr-locks",
+},
+```
+
+So if an agent dies mid-execution, the lock sits for up to 10 minutes before being considered stale. During that window, all subsequent `rr` invocations fail.
+
+### Desired behavior
+
+Two improvements:
+
+**1. Auto-steal stale locks by default**
+
+The `Stale` timeout (10 min) exists but is only checked passively. rr should automatically claim a lock that's older than `Stale` without requiring manual `rr unlock`. Currently, encountering a stale lock still returns an error rather than silently taking over.
+
+If this already works (hard to tell from code inspection alone), then the issue is that 10 minutes is too long for agent workflows. Consider reducing the default `Stale` to 5 minutes, matching the `Timeout` value. An rr command that's been running for 5+ minutes without heartbeat is almost certainly dead.
+
+**2. Lock heartbeat mechanism**
+
+Currently locks are created once with a timestamp. There's no way to distinguish "process is alive and running a 20-minute test suite" from "process died 5 minutes ago." A heartbeat (touch the lock file every 30s while the command runs) would allow much more aggressive stale detection:
+
+- Lock with heartbeat updated in last 60s = alive, don't steal
+- Lock with heartbeat older than 60s = dead, safe to steal immediately
+
+This eliminates the "wait for stale timeout" window entirely for crashed processes while still protecting legitimately running commands.
+
+### Implementation guidance
+
+**Lock file location:** `/tmp/rr-locks/` (configurable via `Lock.Dir`)
+**Lock creation:** Likely in `internal/` somewhere that handles locking (search for `Lock.Dir` or lock file creation)
+
+For heartbeat:
+- Spawn a goroutine when lock is acquired that touches (updates mtime of) the lock file every 30 seconds
+- When checking for stale locks, compare the lock file's mtime against `time.Now()` rather than the lock creation time
+- If mtime is older than 60 seconds, the holder is dead - steal the lock
+
+For reduced stale default:
+- Change `Stale: 10 * time.Minute` to `Stale: 5 * time.Minute` in `DefaultConfig()`
+- Or better: if heartbeat is implemented, reduce to `Stale: 90 * time.Second` (3 missed heartbeats = dead)

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -356,10 +356,20 @@ func anyAncestorPoisoned(pattern string, lines []string) bool {
 }
 
 // dirResolvesExcluded reports whether dirPattern (a directory-unit
-// pattern like "build/") is excluded per the LAST bare directory-unit
-// rule anywhere in the file that names that exact directory. Only exact,
-// non-wildcard matches count, since a wildcard exclude of a directory's
-// children (e.g. "build/*") can never poison the directory itself.
+// pattern like "build/" or "frontend/tests/mocks/") is excluded per the
+// LAST bare directory-unit rule anywhere in the file that names that
+// directory. Only bare directory patterns count, never wildcards, since
+// a wildcard exclude of a directory's children (e.g. "build/*") can
+// never poison the directory itself.
+//
+// Per gitignore's own matching rules, a pattern with no slash (besides a
+// possible trailing one) is UNANCHORED and matches at any depth by its
+// final path segment alone - e.g. "mocks/" matches
+// "frontend/tests/mocks/" the same way it matches a top-level "mocks/".
+// A pattern containing an interior slash is anchored to that exact path.
+// This mirrors real git: verified with git check-ignore that a bare
+// "mocks/" rule poisons a "!frontend/tests/mocks/data/" negation even
+// though the exclude pattern is never anchored to the full ancestor path.
 func dirResolvesExcluded(dirPattern string, lines []string) bool {
 	excluded := false
 	for _, line := range lines {
@@ -369,12 +379,30 @@ func dirResolvesExcluded(dirPattern string, lines []string) bool {
 			candidate = line[1:]
 		}
 		candidate = unescapeGitignorePattern(candidate)
-		if candidate != dirPattern {
+		if !dirPatternMatches(candidate, dirPattern) {
 			continue
 		}
 		excluded = !negated
 	}
 	return excluded
+}
+
+// dirPatternMatches reports whether gitignore directory pattern matches
+// ancestor (both normalized as "a/b/" style paths). An exact match always
+// counts. An unanchored pattern (no interior slash) additionally matches
+// by ancestor's final path segment, per gitignore's own rule that such a
+// pattern applies at any depth.
+func dirPatternMatches(pattern, ancestor string) bool {
+	if pattern == ancestor {
+		return true
+	}
+	interior := strings.TrimSuffix(pattern, "/")
+	if strings.Contains(interior, "/") {
+		return false // anchored to a specific path, already checked above
+	}
+	trimmedAncestor := strings.TrimSuffix(ancestor, "/")
+	segments := strings.Split(trimmedAncestor, "/")
+	return segments[len(segments)-1]+"/" == pattern
 }
 
 // ancestorDirs returns rsync directory-match patterns (each ending in "/")

--- a/internal/sync/sync.go
+++ b/internal/sync/sync.go
@@ -185,7 +185,11 @@ func BuildArgs(conn *host.Connection, localDir string, cfg config.SyncConfig) ([
 	// Respect .gitignore patterns as additional excludes. Placed after explicit
 	// preserves and excludes so .rr.yaml rules take precedence (rsync is first-match-wins).
 	if cfg.RespectGitignore {
-		args = append(args, "--filter=:- .gitignore")
+		gitignoreArgs, err := gitignoreFilterArgs(localDir)
+		if err != nil {
+			return nil, err
+		}
+		args = append(args, gitignoreArgs...)
 	}
 
 	// Add custom flags from config
@@ -195,6 +199,213 @@ func BuildArgs(conn *host.Connection, localDir string, cfg config.SyncConfig) ([
 	args = append(args, localDir, remoteDest)
 
 	return args, nil
+}
+
+// gitignoreFilterArgs reads the top-level .gitignore in localDir and
+// translates it into rsync --filter rules.
+//
+// This exists because rsync's own .gitignore support (--filter=':- .gitignore')
+// has no concept of git's "!pattern" negation. Rsync's merge-file format
+// only understands a bare "!" as "clear every rule read so far" - it is not
+// per-pattern and does not mean "re-include this path". So a .gitignore
+// containing an unanchored "data/" exclude followed by
+// "!frontend/tests/mocks/data/" to carve out an exception (a completely
+// normal, common pattern) would silently drop that path from every sync,
+// with git itself reporting the path as NOT ignored the whole time -
+// making the discrepancy very hard to spot.
+//
+// Git resolves a .gitignore with "last matching pattern wins" (top to
+// bottom). Rsync's filter list is "first matching rule wins". To reproduce
+// git's semantics we emit rules in REVERSED file order, with each
+// "!pattern" line becoming an rsync include ("+") and every other line
+// becoming an exclude ("-").
+//
+// There's one more wrinkle, straight from `git help gitignore`: "It is not
+// possible to re-include a file if a parent directory of that file is
+// excluded." Whether a negation is actually reachable depends on
+// resolving EVERY ancestor directory independently, root to leaf, and
+// stopping the moment one resolves as excluded - deeper patterns never
+// get a say once that happens. Concretely (all verified against real
+// git):
+//
+//   - A bare directory-unit exclude ("build/") always kills a negation of
+//     anything underneath, in EITHER file order, unless "build/" is
+//     itself separately re-included by its own "!build/" line.
+//   - A wildcard exclude of a directory's children ("build/*") does NOT
+//     poison the directory itself, so "!build/keep-me/" can still live -
+//     provided it comes after "build/*" in the file (ordinary
+//     last-match-wins).
+//   - This nests: "a/" excluded then "!a/" re-included then "a/b/"
+//     excluded then "!a/b/" re-included means a/b/anything is NOT
+//     ignored, because each ancestor resolves independently once its own
+//     parent is clear.
+//
+// We approximate full git resolution with a bounded check scoped to what
+// this function actually needs (only NEGATED lines can possibly need
+// rescuing from an rsync exclude): for a "!pattern" line, walk pattern's
+// ancestors root to leaf. An ancestor is "poisoned" if the LAST bare
+// directory-unit pattern for that exact ancestor, anywhere earlier in the
+// file, is an exclude with no later re-include for that same ancestor.
+// The negation is dead the moment any ancestor is poisoned. This covers
+// arbitrarily deep nesting without a full gitignore glob matcher, at the
+// cost of only comparing bare directory-unit patterns exactly (not
+// wildcards) - sufficient because a wildcard exclude can never poison an
+// ancestor per the rule above.
+//
+// Live negations still need their ancestor directories explicitly
+// included, or rsync will never descend far enough to see the file - an
+// exclude on an ancestor directory prevents rsync from looking inside it
+// at all, independent of the poisoned-ancestor check above.
+//
+// Scope: only the repo-root .gitignore is read, matching what rsync's
+// previous ':- .gitignore' invocation covered. Nested per-directory
+// .gitignore files are not merged; if that's needed later, extend this to
+// walk the tree the way git itself does.
+func gitignoreFilterArgs(localDir string) ([]string, error) {
+	path := filepath.Join(localDir, ".gitignore")
+	f, err := os.Open(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, errors.WrapWithCode(err, errors.ErrSync,
+			"Couldn't read .gitignore",
+			"Check the file's permissions or disable respect_gitignore in .rr.yaml.")
+	}
+	defer f.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		lines = append(lines, trimmed)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, errors.WrapWithCode(err, errors.ErrSync,
+			"Couldn't read .gitignore",
+			"Check the file's permissions or disable respect_gitignore in .rr.yaml.")
+	}
+
+	var args []string
+	seenIncludes := make(map[string]bool)
+
+	// Reversed file order: git's last-matching-pattern-wins becomes
+	// rsync's first-matching-rule-wins.
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+
+		negated := strings.HasPrefix(line, "!")
+		pattern := line
+		if negated {
+			pattern = line[1:]
+		}
+		pattern = unescapeGitignorePattern(pattern)
+
+		if negated {
+			if anyAncestorPoisoned(pattern, lines) {
+				// Dead negation: an ancestor directory resolves excluded
+				// per git's own rules. Git can never resurrect this path
+				// either, so emit nothing.
+				continue
+			}
+			for _, parent := range ancestorDirs(pattern) {
+				if seenIncludes[parent] {
+					continue
+				}
+				seenIncludes[parent] = true
+				args = append(args, fmt.Sprintf("--filter=+ %s", parent))
+			}
+			if !seenIncludes[pattern] {
+				seenIncludes[pattern] = true
+				args = append(args, fmt.Sprintf("--filter=+ %s", pattern))
+			}
+		} else {
+			args = append(args, fmt.Sprintf("--filter=- %s", pattern))
+		}
+	}
+
+	return args, nil
+}
+
+// unescapeGitignorePattern strips gitignore's backslash-escape from a
+// literal leading "!" or "#" so rsync sees the intended literal character.
+func unescapeGitignorePattern(pattern string) string {
+	if strings.HasPrefix(pattern, "\\!") || strings.HasPrefix(pattern, "\\#") {
+		return pattern[1:]
+	}
+	return pattern
+}
+
+// anyAncestorPoisoned reports whether any ancestor directory of pattern
+// resolves to excluded, per git's rule that a directory-unit exclude with
+// no later re-include for that exact directory poisons everything
+// beneath it regardless of deeper negations. Ancestors are checked root
+// to leaf so a poisoned parent short-circuits before a clear grandparent
+// could otherwise be mistaken for permission to descend.
+func anyAncestorPoisoned(pattern string, lines []string) bool {
+	for _, ancestor := range ancestorDirs(pattern) {
+		if dirResolvesExcluded(ancestor, lines) {
+			return true
+		}
+	}
+	return false
+}
+
+// dirResolvesExcluded reports whether dirPattern (a directory-unit
+// pattern like "build/") is excluded per the LAST bare directory-unit
+// rule anywhere in the file that names that exact directory. Only exact,
+// non-wildcard matches count, since a wildcard exclude of a directory's
+// children (e.g. "build/*") can never poison the directory itself.
+func dirResolvesExcluded(dirPattern string, lines []string) bool {
+	excluded := false
+	for _, line := range lines {
+		negated := strings.HasPrefix(line, "!")
+		candidate := line
+		if negated {
+			candidate = line[1:]
+		}
+		candidate = unescapeGitignorePattern(candidate)
+		if candidate != dirPattern {
+			continue
+		}
+		excluded = !negated
+	}
+	return excluded
+}
+
+// ancestorDirs returns rsync directory-match patterns (each ending in "/")
+// for every parent directory of pattern, from shallowest to deepest. E.g.
+// "frontend/tests/mocks/data/" yields ["frontend/", "frontend/tests/",
+// "frontend/tests/mocks/"].
+func ancestorDirs(pattern string) []string {
+	// Anchoring ("/" prefix) doesn't change parent segmentation, only where
+	// rsync starts matching from - strip it for splitting, the "/" prefix
+	// on each emitted parent below re-adds equivalent anchoring behavior
+	// via rsync's leading-slash rule.
+	anchored := strings.HasPrefix(pattern, "/")
+	trimmed := strings.TrimPrefix(pattern, "/")
+	trimmed = strings.TrimSuffix(trimmed, "/")
+
+	segments := strings.Split(trimmed, "/")
+	if len(segments) <= 1 {
+		return nil
+	}
+
+	var parents []string
+	var prefix string
+	for _, seg := range segments[:len(segments)-1] {
+		prefix += seg + "/"
+		if anchored {
+			parents = append(parents, "/"+prefix)
+		} else {
+			parents = append(parents, prefix)
+		}
+	}
+	return parents
 }
 
 // streamOutput reads from r and writes each line to w.

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -456,6 +456,34 @@ func TestBuildArgs_GitignoreTranslation(t *testing.T) {
 			"innermost negation must be live since every ancestor resolves not-excluded")
 	})
 
+	t.Run("unanchored bare directory exclude poisons a deeper ancestor by basename", func(t *testing.T) {
+		dir := t.TempDir()
+		// Verified against real git (git check-ignore -v): a bare,
+		// unanchored "mocks/" rule matches ANY directory named "mocks"
+		// at any depth - including frontend/tests/mocks/ - per gitignore's
+		// own rule that a pattern with no interior slash is unanchored.
+		// It poisons the negation just like an exact "frontend/tests/mocks/"
+		// exclude would, even though the two pattern strings don't match
+		// textually. Regression test for a CodeRabbit-flagged gap where
+		// dirResolvesExcluded only compared ancestors by exact string
+		// equality and missed this case.
+		writeGitignore(t, dir,
+			"mocks/",
+			"!frontend/tests/mocks/data/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=- mocks/")
+		assert.NotContains(t, args, "--filter=+ frontend/tests/mocks/data/",
+			"unanchored ancestor exclude must poison the negation, matching real git")
+		for _, a := range args {
+			assert.False(t, strings.HasPrefix(a, "--filter=+ "),
+				"no negation should survive when an unanchored ancestor exclude poisons it, got: %s", a)
+		}
+	})
+
 	t.Run("no .gitignore file means no filter rules and no error", func(t *testing.T) {
 		dir := t.TempDir() // empty, no .gitignore
 

--- a/internal/sync/sync_test.go
+++ b/internal/sync/sync_test.go
@@ -212,21 +212,6 @@ func TestBuildArgs(t *testing.T) {
 			},
 		},
 		{
-			name: "gitignore filter enabled by default",
-			conn: &host.Connection{
-				Name:  "test-host",
-				Alias: "test-alias",
-				Host:  config.Host{Dir: "~/projects/myapp"},
-			},
-			localDir: "/home/user/myapp",
-			cfg: config.SyncConfig{
-				RespectGitignore: true,
-			},
-			checkArgs: func(t *testing.T, args []string) {
-				assert.Contains(t, args, "--filter=:- .gitignore")
-			},
-		},
-		{
 			name: "gitignore filter disabled",
 			conn: &host.Connection{
 				Name:  "test-host",
@@ -240,42 +225,28 @@ func TestBuildArgs(t *testing.T) {
 			checkArgs: func(t *testing.T, args []string) {
 				for _, arg := range args {
 					assert.NotContains(t, arg, ".gitignore", "should not contain gitignore filter")
+					assert.False(t, strings.HasPrefix(arg, "--filter=+ "), "should not include any gitignore-derived include rule")
 				}
 			},
 		},
 		{
-			name: "gitignore filter comes after excludes",
+			name: "gitignore filter enabled but no .gitignore present",
 			conn: &host.Connection{
 				Name:  "test-host",
 				Alias: "test-alias",
 				Host:  config.Host{Dir: "~/projects/myapp"},
 			},
+			// Nonexistent path: BuildArgs should treat a missing .gitignore
+			// as "nothing to add", not an error.
 			localDir: "/home/user/myapp",
 			cfg: config.SyncConfig{
 				RespectGitignore: true,
-				Exclude:          []string{".git/", "node_modules/"},
-				Flags:            []string{"--compress"},
 			},
 			checkArgs: func(t *testing.T, args []string) {
-				gitignoreIdx := -1
-				lastExcludeIdx := -1
-				firstFlagIdx := -1
-				for i, arg := range args {
-					if arg == "--filter=:- .gitignore" {
-						gitignoreIdx = i
-					}
-					if strings.HasPrefix(arg, "--exclude=") {
-						lastExcludeIdx = i
-					}
-					if arg == "--compress" {
-						firstFlagIdx = i
-					}
+				for _, arg := range args {
+					assert.False(t, strings.HasPrefix(arg, "--filter=+ ") || strings.HasPrefix(arg, "--filter=- "),
+						"no .gitignore present, should not emit any gitignore-derived filter rule")
 				}
-				require.Greater(t, gitignoreIdx, -1, "gitignore filter should be present")
-				require.Greater(t, lastExcludeIdx, -1, "exclude should be present")
-				require.Greater(t, firstFlagIdx, -1, "custom flag should be present")
-				assert.Greater(t, gitignoreIdx, lastExcludeIdx, "gitignore filter should come after excludes")
-				assert.Less(t, gitignoreIdx, firstFlagIdx, "gitignore filter should come before custom flags")
 			},
 		},
 		{
@@ -301,6 +272,228 @@ func TestBuildArgs(t *testing.T) {
 			tt.checkArgs(t, args)
 		})
 	}
+}
+
+// writeGitignore writes the given lines (in order) to a .gitignore in dir.
+func writeGitignore(t *testing.T, dir string, lines ...string) {
+	t.Helper()
+	content := strings.Join(lines, "\n") + "\n"
+	err := os.WriteFile(filepath.Join(dir, ".gitignore"), []byte(content), 0o644)
+	require.NoError(t, err)
+}
+
+// indexOf returns the index of the first arg equal to target, or -1.
+func indexOf(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestBuildArgs_GitignoreTranslation covers translating .gitignore into rsync
+// filter rules, in particular the "!negation" case that rsync's own
+// '--filter=:- .gitignore' cannot express (rsync's merge-file syntax has no
+// per-pattern negation; a bare "!" there means "clear all rules read so
+// far", not "re-include this path"). Regression coverage for the bug where
+// `data/` + `!frontend/tests/mocks/data/` in .gitignore silently dropped
+// that directory from every rr sync, even though git itself correctly
+// treated the path as not ignored.
+func TestBuildArgs_GitignoreTranslation(t *testing.T) {
+	conn := &host.Connection{
+		Name:  "test-host",
+		Alias: "test-alias",
+		Host:  config.Host{Dir: "~/projects/myapp"},
+	}
+
+	t.Run("simple excludes with no negation", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitignore(t, dir, "node_modules/", "*.log", "# a comment", "", ".DS_Store")
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=- node_modules/")
+		assert.Contains(t, args, "--filter=- *.log")
+		assert.Contains(t, args, "--filter=- .DS_Store")
+		// Comments and blank lines must not turn into rules.
+		for _, a := range args {
+			assert.NotContains(t, a, "# a comment")
+		}
+	})
+
+	t.Run("negated pattern becomes an include, not silently dropped", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitignore(t, dir,
+			"data/",
+			"!frontend/tests/mocks/data/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=+ frontend/tests/mocks/data/",
+			"negated pattern must become an rsync include rule")
+		assert.Contains(t, args, "--filter=- data/",
+			"the exclude that the negation carves an exception out of must still be present")
+	})
+
+	t.Run("negated pattern includes ancestor directories so rsync can descend", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitignore(t, dir,
+			"data/",
+			"!frontend/tests/mocks/data/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		// Without these, rsync would never look inside frontend/, frontend/tests/,
+		// or frontend/tests/mocks/ in the first place - an exclude on an ancestor
+		// stops descent regardless of rules that come later.
+		assert.Contains(t, args, "--filter=+ frontend/")
+		assert.Contains(t, args, "--filter=+ frontend/tests/")
+		assert.Contains(t, args, "--filter=+ frontend/tests/mocks/")
+	})
+
+	t.Run("wildcard exclude of children lets a specific child negation live, regardless of order", func(t *testing.T) {
+		dir := t.TempDir()
+		// Verified against real git (git status --ignored --porcelain):
+		// "build/*" excludes each ENTRY inside build/ individually, but
+		// never build/ itself, so "!build/keep-me/" can still resurrect
+		// that one child. This is the standard "ignore everything in a
+		// dir except X" idiom - unlike a bare "build/" exclude (covered
+		// below), which always kills negations underneath it.
+		writeGitignore(t, dir,
+			"build/*",
+			"!build/keep-me/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		keepIdx := indexOf(args, "--filter=+ build/keep-me/")
+		excludeIdx := indexOf(args, "--filter=- build/*")
+		require.NotEqual(t, -1, keepIdx, "include rule for build/keep-me/ must be present")
+		require.NotEqual(t, -1, excludeIdx, "exclude rule for build/* must be present")
+		// Rsync is first-match-wins, so to reproduce git's last-match-wins
+		// result the include must be emitted BEFORE the exclude, even
+		// though it appeared AFTER it in the source .gitignore.
+		assert.Less(t, keepIdx, excludeIdx,
+			"include for the more specific negated path must come before the broader exclude")
+	})
+
+	t.Run("a bare directory exclude always kills negations underneath it, regardless of order", func(t *testing.T) {
+		dir := t.TempDir()
+		// Per `git help gitignore`: "It is not possible to re-include a
+		// file if a parent directory of that file is excluded." Unlike
+		// "build/*" above, a bare "build/" exclude covers the directory
+		// itself as a unit, so no negation of a path underneath it can
+		// ever be live unless "build/" is itself re-included first -
+		// verified with real git for BOTH line orderings.
+		writeGitignore(t, dir,
+			"!build/keep-me/",
+			"build/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=- build/")
+		assert.NotContains(t, args, "--filter=+ build/keep-me/",
+			"dead negation (ancestor excluded by a bare dir pattern) must not produce an include rule")
+		assert.NotContains(t, args, "--filter=+ build/",
+			"dead negation must not produce ancestor include rules either")
+	})
+
+	t.Run("nested alternating negations are all dead if the top-level exclude is never itself re-included", func(t *testing.T) {
+		dir := t.TempDir()
+		// Verified against real git (git status --ignored --porcelain):
+		// with "a/" excluded and never re-included by an earlier negation,
+		// every deeper "!a/b/" / "!a/b/c/" negation is unreachable - git
+		// reports a/file.txt, a/b/file.txt, and a/b/c/file.txt as ALL
+		// ignored, matched by the "a/" rule alone.
+		writeGitignore(t, dir,
+			"a/",
+			"!a/b/",
+			"a/b/*",
+			"!a/b/c/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=- a/")
+		for _, a := range args {
+			assert.False(t, strings.HasPrefix(a, "--filter=+ "),
+				"every negation under a dead top-level exclude must be dropped, got: %s", a)
+		}
+	})
+
+	t.Run("re-including each ancestor in turn resurrects a deeply nested negation", func(t *testing.T) {
+		dir := t.TempDir()
+		// Verified against real git: p/ excluded then re-included via
+		// !p/, p/c/ excluded then re-included via !p/c/, p/c/g/ excluded
+		// then re-included via !p/c/g/ - every ancestor independently
+		// resolves NOT ignored, so p/c/g/file.txt is not ignored either
+		// (git check-ignore exits 1 / no match). Unlike the dead case
+		// above, each directory here gets its own explicit re-include
+		// before the next level is excluded.
+		writeGitignore(t, dir,
+			"p/",
+			"!p/",
+			"p/c/",
+			"!p/c/",
+			"p/c/g/",
+			"!p/c/g/",
+		)
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		assert.Contains(t, args, "--filter=+ p/c/g/",
+			"innermost negation must be live since every ancestor resolves not-excluded")
+	})
+
+	t.Run("no .gitignore file means no filter rules and no error", func(t *testing.T) {
+		dir := t.TempDir() // empty, no .gitignore
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{RespectGitignore: true})
+		require.NoError(t, err)
+
+		for _, a := range args {
+			assert.False(t, strings.HasPrefix(a, "--filter=+ ") || strings.HasPrefix(a, "--filter=- "),
+				"no .gitignore present, should not emit any gitignore-derived filter rule")
+		}
+	})
+
+	t.Run("gitignore rules come after explicit excludes and before custom flags", func(t *testing.T) {
+		dir := t.TempDir()
+		writeGitignore(t, dir, "build/")
+
+		args, err := BuildArgs(conn, dir, config.SyncConfig{
+			RespectGitignore: true,
+			Exclude:          []string{".git/", "node_modules/"},
+			Flags:            []string{"--compress"},
+		})
+		require.NoError(t, err)
+
+		gitignoreIdx := indexOf(args, "--filter=- build/")
+		lastExcludeIdx := -1
+		for i, a := range args {
+			if strings.HasPrefix(a, "--exclude=") {
+				lastExcludeIdx = i
+			}
+		}
+		firstFlagIdx := indexOf(args, "--compress")
+
+		require.NotEqual(t, -1, gitignoreIdx, "gitignore filter rule should be present")
+		require.NotEqual(t, -1, lastExcludeIdx, "exclude should be present")
+		require.NotEqual(t, -1, firstFlagIdx, "custom flag should be present")
+		assert.Greater(t, gitignoreIdx, lastExcludeIdx, "gitignore rules should come after explicit excludes")
+		assert.Less(t, gitignoreIdx, firstFlagIdx, "gitignore rules should come before custom flags")
+	})
 }
 
 // TestBuildArgs_SSHBatchMode verifies that BatchMode=yes is included in the SSH command.


### PR DESCRIPTION
## Summary

- \`respect_gitignore\` passed \`--filter=':- .gitignore'\` straight to rsync, but rsync's merge-file syntax has no per-pattern \`!negation\` — a bare \`!\` there means "clear every rule read so far," not "re-include this path." Any \`.gitignore\` using the common "ignore broadly, carve out an exception" idiom (e.g. \`data/\` + \`!frontend/tests/mocks/data/\`) silently dropped the excepted path from every sync, even though \`git status\`/\`git check-ignore\` correctly reported it as not ignored. Found this while debugging real e2e test failures on a project using exactly this pattern.
- \`gitignoreFilterArgs()\` now reads \`.gitignore\` directly and emits explicit rsync \`+\`/\`-\` filter rules: reversed file order (git is last-match-wins, rsync is first-match-wins), with negations resolved per git's real rule that a file can't be re-included once an ancestor directory is excluded — verified against real git for bare-directory-exclude, wildcard-exclude, and multi-level re-include-chain cases.
- Resolves FEEDBACK.md Issue 3, whose originally-suggested implementation is what introduced this bug.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`golangci-lint run ./...\` — 0 issues
- [x] \`go test ./...\` — all packages pass
- [x] New \`TestBuildArgs_GitignoreTranslation\` suite covers: simple excludes, live negation + ancestor-include generation, wildcard-exclude-then-negation (live), bare-directory-exclude-then-negation (dead, both orders), deep alternating dead chain, deep alternating re-include chain (live), no-.gitignore-present, and ordering relative to explicit excludes/flags — each case verified against real \`git status --ignored\`/\`git check-ignore -v\` output before being encoded as a test assertion

https://claude.ai/code/session_01RQvYK6WC7prYSv2EDtzBPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync behavior when respecting `.gitignore`, including better handling of ignore rules, negations, and nested directory exceptions.
  * Prevented failures when no `.gitignore` file is present.
  * Reduced stale lock issues after interrupted sessions.

* **New Features**
  * Sync now preserves more of the expected ignore/include behavior during file transfer.
  * Added expanded guidance for agent-friendly workflows and output expectations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->