### PR TITLE
fix(deps): bump Go toolchain to 1.25.11 to resolve stdlib CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary

- CI's govulncheck step was failing on two Go 1.25.10 stdlib CVEs reachable from our code: [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) (`net/textproto`, via `progressReader.Read` -> HTTP body read) and [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) (`crypto/x509`, via TLS hostname verification in `progressReader.Read` and `monitor.Collect`). Both are fixed upstream in Go 1.25.11.
- Toolchain-only bump (`go.mod`'s `go` directive), no dependency changes.
- Verified locally: `govulncheck ./...` reports "No vulnerabilities found" after the bump.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] `govulncheck ./...` — no vulnerabilities found (was 2 before the bump)

https://claude.ai/code/session_01RQvYK6WC7prYSv2EDtzBPs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain version to a newer patch release for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->