### PR TITLE
docs: update changelog for v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.0] - 2026-07-26
 
 ### Breaking Changes
 


### PR DESCRIPTION
Stamps the [Unreleased] section as [0.23.0] - 2026-07-26 ahead of tagging the release. Covers the agent compatibility round 2 work from #227.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to mark the latest changes as version **0.23.0**, dated **July 26, 2026**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->