### PR TITLE
fix: v0.23.0 manual QA findings (quiet pytest summaries, --config fallback, task flag hint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Test summaries extract from quiet pytest output** - `details.summary` now parses the bare `5 passed in 4.20s` line that pytest `-q`/`-qq` emits (and filtered pipelines pass through); previously only the `==== ... ====` decorated summary was recognized, so quiet runs got no summary in the result envelope.
+- **Bad explicit `--config` no longer falls back silently** - `rr --config /bad/path.yaml tasks` errored from an empty directory but silently listed tasks from a discovered `.rr.yaml` when one existed; it now fails either way.
+- **Unknown task flags suggest `--`** - `rr test-opendata -k foo` died with a bare cobra "unknown shorthand flag" error; it now explains that rr parses flags first and suggests `rr <task> -- <args>` to pass flags through to the task.
+
 ## [0.23.0] - 2026-07-26
 
 ### Breaking Changes

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -525,8 +525,15 @@ func renderTaskSummary(_ *ui.PhaseDisplay, result *exec.TaskResult, taskName str
 
 // ListTasks displays all available tasks from the configuration.
 func ListTasks() error {
-	// Find and load config
-	cfgPath, err := config.Find("")
+	// Find and load config, honoring an explicit --config flag: a bad
+	// explicit path must error rather than silently falling back to a
+	// discovered .rr.yaml.
+	cfgPath, err := config.Find(Config())
+	if err == nil && cfgPath == "" {
+		err = errors.New(errors.ErrConfig,
+			"No .rr.yaml found in this directory or parent directories",
+			"Run 'rr init' to create one, or check you're in the right directory.")
+	}
 	if err != nil {
 		if tasksJSON || MachineMode() {
 			return WriteJSONFromError(os.Stdout, errors.WrapWithCode(err, errors.ErrConfig,
@@ -685,6 +692,21 @@ func RegisterTaskCommands(cfg *config.Config) {
 }
 
 // createTaskCommand creates a cobra command for a task.
+// taskFlagErrorFunc turns cobra's unknown-flag errors on generated task
+// commands into a hint about the '--' separator: flag-looking task args
+// (pytest's -k, -x, ...) hit rr's own flag parser first and die with
+// "unknown shorthand flag" unless they come after '--'.
+func taskFlagErrorFunc(name string) func(*cobra.Command, error) error {
+	return func(_ *cobra.Command, err error) error {
+		if err == nil || !strings.Contains(err.Error(), "unknown") {
+			return err
+		}
+		return errors.New(errors.ErrConfig,
+			err.Error()+" (rr parses flags before the task sees them)",
+			fmt.Sprintf("Put task flags after '--' so they pass through: rr %s -- <args>", name))
+	}
+}
+
 func createTaskCommand(name string, task config.TaskConfig) *cobra.Command {
 	// Check if this is a parallel task
 	if config.IsParallelTask(&task) {
@@ -727,6 +749,8 @@ func createTaskCommand(name string, task config.TaskConfig) *cobra.Command {
 		cmd.Flags().BoolVar(&skipDepsFlag, "skip-deps", false, "skip dependencies, run only this task")
 		cmd.Flags().StringVar(&fromFlag, "from", "", "start from this task in the dependency chain")
 	}
+
+	cmd.SetFlagErrorFunc(taskFlagErrorFunc(name))
 
 	return cmd
 }
@@ -797,6 +821,10 @@ func createParallelTaskCommand(name string, task config.TaskConfig) *cobra.Comma
 	cmd.Flags().IntVar(&maxParallelFlag, "max-parallel", 0, "limit concurrent task execution (0 = unlimited)")
 	cmd.Flags().BoolVar(&noLogsFlag, "no-logs", false, "don't save output to log files")
 	cmd.Flags().BoolVar(&dryRunFlag, "dry-run", false, "show execution plan without running")
+
+	if task.ForwardArgs {
+		cmd.SetFlagErrorFunc(taskFlagErrorFunc(name))
+	}
 
 	return cmd
 }

--- a/internal/cli/task.go
+++ b/internal/cli/task.go
@@ -530,9 +530,13 @@ func ListTasks() error {
 	// discovered .rr.yaml.
 	cfgPath, err := config.Find(Config())
 	if err == nil && cfgPath == "" {
-		err = errors.New(errors.ErrConfig,
+		notFound := errors.New(errors.ErrConfig,
 			"No .rr.yaml found in this directory or parent directories",
 			"Run 'rr init' to create one, or check you're in the right directory.")
+		if tasksJSON || MachineMode() {
+			return WriteJSONFromError(os.Stdout, notFound)
+		}
+		return notFound
 	}
 	if err != nil {
 		if tasksJSON || MachineMode() {
@@ -701,8 +705,8 @@ func taskFlagErrorFunc(name string) func(*cobra.Command, error) error {
 		if err == nil || !strings.Contains(err.Error(), "unknown") {
 			return err
 		}
-		return errors.New(errors.ErrConfig,
-			err.Error()+" (rr parses flags before the task sees them)",
+		return errors.WrapWithCode(err, errors.ErrConfig,
+			"rr parses flags before the task sees them",
 			fmt.Sprintf("Put task flags after '--' so they pass through: rr %s -- <args>", name))
 	}
 }

--- a/internal/cli/task_test.go
+++ b/internal/cli/task_test.go
@@ -460,3 +460,23 @@ func TestCreateParallelTaskCommand_ForwardArgsUseLine(t *testing.T) {
 	assert.NotContains(t, cmdWithout.Use, "[args...]",
 		"regular parallel task should not show [args...] in Use string")
 }
+
+// TestTaskCommand_UnknownFlagHint verifies that flag-looking task args get
+// a hint about the '--' separator instead of a bare cobra parse error.
+func TestTaskCommand_UnknownFlagHint(t *testing.T) {
+	task := config.TaskConfig{Run: "pytest {args}"}
+	cmd := createTaskCommand("my-task", task)
+	cmd.SetArgs([]string{"-k", "foo"})
+	execErr := cmd.Execute()
+	require.Error(t, execErr)
+	assert.Contains(t, execErr.Error(), "unknown shorthand flag")
+	assert.Contains(t, execErr.Error(), "rr my-task -- <args>")
+}
+
+// TestTaskCommand_KnownFlagsStillParse verifies the flag error hint doesn't
+// interfere with rr's own flags.
+func TestTaskCommand_KnownFlagsStillParse(t *testing.T) {
+	task := config.TaskConfig{Run: "pytest {args}"}
+	cmd := createTaskCommand("my-task", task)
+	require.NoError(t, cmd.Flags().Parse([]string{"--local", "--tail", "5"}))
+}

--- a/internal/output/formatters/detect_test.go
+++ b/internal/output/formatters/detect_test.go
@@ -155,6 +155,25 @@ tests/test_example.py::test_skip SKIPPED [100%]
 	assert.Equal(t, 1, summary.Skipped)
 }
 
+func TestExtractTestSummary_PytestQuiet(t *testing.T) {
+	// -q/-qq emit no per-test lines and an undecorated summary; counts
+	// must come from the bare summary line.
+	command := "bash -c 'cd opendata && uv run pytest \"$@\" -n 4 --no-cov -qq --tb=short' rr tests/foo.py"
+	output := []byte("bringing up nodes...\n5 passed in 4.20s\n")
+
+	summary, ok := ExtractTestSummary(command, output)
+	assert.True(t, ok)
+	assert.Equal(t, 5, summary.Passed)
+	assert.Zero(t, summary.Failed)
+
+	output = []byte("bringing up nodes...\n2 failed, 3 passed, 1 skipped in 1.10s\n")
+	summary, ok = ExtractTestSummary(command, output)
+	assert.True(t, ok)
+	assert.Equal(t, 3, summary.Passed)
+	assert.Equal(t, 2, summary.Failed)
+	assert.Equal(t, 1, summary.Skipped)
+}
+
 func TestExtractTestSummary_GoTest(t *testing.T) {
 	command := "go test ./..."
 	output := []byte(`

--- a/internal/output/formatters/pytest.go
+++ b/internal/output/formatters/pytest.go
@@ -108,6 +108,13 @@ var (
 	// Matches summary line: 1 failed, 1 passed, 1 skipped in 0.03s
 	pytestSummaryPattern = regexp.MustCompile(`=+\s*(\d+\s+\w+(?:,\s*\d+\s+\w+)*)\s+in\s+[\d.]+s\s*=+`)
 
+	// Quiet mode (-q/-qq) drops the ==== decoration and prints the bare
+	// summary alone on a line: "5 passed in 4.20s".
+	pytestBareSummaryPattern = regexp.MustCompile(`^\d+\s+\w+(?:,\s*\d+\s+\w+)*\s+in\s+[\d.]+s$`)
+
+	// Extracts "<count> <word>" pairs from a summary line.
+	pytestCountPairPattern = regexp.MustCompile(`(\d+)\s+(\w+)`)
+
 	// Matches the failures section header
 	pytestFailuresSectionStart = regexp.MustCompile(`^=+\s*FAILURES\s*=+$`)
 	pytestFailuresSectionEnd   = regexp.MustCompile(`^=+\s*short test summary`)
@@ -166,8 +173,8 @@ func (f *PytestFormatter) ProcessLine(line string) string {
 		}
 	}
 
-	// Check for summary line
-	if pytestSummaryPattern.MatchString(trimmed) {
+	// Check for summary line (decorated, or bare in -q/-qq mode)
+	if pytestSummaryPattern.MatchString(trimmed) || pytestBareSummaryPattern.MatchString(trimmed) {
 		f.summaryLine = trimmed
 	}
 
@@ -349,7 +356,9 @@ func (f *PytestFormatter) GetTestFailures() []output.TestFailure {
 }
 
 // GetTestCounts implements output.TestSummaryProvider.
-// Returns (passed, failed, skipped, errors) counts.
+// Returns (passed, failed, skipped, errors) counts. Quiet runs (-q/-qq)
+// emit no per-test result lines, so when none were seen the counts come
+// from the final summary line instead.
 func (f *PytestFormatter) GetTestCounts() (passed, failed, skipped, errors int) {
 	for _, r := range f.results {
 		switch r.Status {
@@ -361,6 +370,32 @@ func (f *PytestFormatter) GetTestCounts() (passed, failed, skipped, errors int) 
 			skipped++
 		case "ERROR":
 			errors++
+		}
+	}
+	if passed == 0 && failed == 0 && skipped == 0 && errors == 0 && f.summaryLine != "" {
+		return parseSummaryCounts(f.summaryLine)
+	}
+	return
+}
+
+// parseSummaryCounts extracts test counts from a pytest summary line like
+// "2 failed, 3 passed, 1 skipped in 1.10s". Unknown categories (xfailed,
+// deselected, warnings, ...) are ignored.
+func parseSummaryCounts(line string) (passed, failed, skipped, errors int) {
+	for _, m := range pytestCountPairPattern.FindAllStringSubmatch(line, -1) {
+		n, err := strconv.Atoi(m[1])
+		if err != nil {
+			continue
+		}
+		switch m[2] {
+		case "passed":
+			passed += n
+		case "failed":
+			failed += n
+		case "skipped":
+			skipped += n
+		case "error", "errors":
+			errors += n
 		}
 	}
 	return

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -416,6 +416,11 @@ EOF
     run_test "config: invalid path (should fail)" 1 \
         env -C "$empty_dir" "$RR_BIN" --config "/nonexistent/path.yaml" tasks
     rm -rf "$empty_dir"
+
+    # A bad explicit --config must fail even when the cwd has a valid
+    # .rr.yaml - silently falling back to it hides the typo.
+    run_test "config: invalid path ignores local .rr.yaml (should fail)" 1 \
+        env -C "$test_dir" "$RR_BIN" --config "/nonexistent/path.yaml" tasks
 }
 
 # Test --local flag with tasks


### PR DESCRIPTION
Fixes three findings from manual QA of v0.23.0, stress-tested against the opendata repo on real hosts (m4-mini/m1-linux).

## Findings and fixes

**1. `details.summary` never extracted for quiet pytest runs**
Every opendata task runs pytest with `-qq` behind a grep filter, which emits a bare `5 passed in 4.20s` instead of the `==== ... ====` decorated summary. The formatter's summary regex required the decoration, and `GetTestCounts` only counted verbose per-test `PASSED`/`FAILED` lines - so the envelope summary feature added in v0.23.0 was invisible to exactly the workload that motivated it. Bare summary lines now match, and counts fall back to parsing the summary line when no per-test lines were seen.

Verified: `rr test-opendata tests/test_fixtures.py` now reports `"summary":{"passed":5,"failed":0,"skipped":0,"errors":0}`.

**2. Bad explicit `--config` silently ignored when cwd has `.rr.yaml`**
`rr --config /nonexistent/path.yaml tasks` failed correctly from an empty directory but silently listed tasks from the discovered local `.rr.yaml` (exit 0) when one existed - `ListTasks` called `config.Find("")` instead of honoring the flag. It now uses the explicit path and fails on a bad one. New e2e assertion covers the with-local-config case.

**3. Flag-looking task args die with a bare cobra error**
`rr test-opendata -k foo` failed with `unknown shorthand flag: 'k'` and no guidance, undercutting the `{args}` forwarding feature. Generated task commands (and `forward_args` parallel tasks) now attach a flag-error handler that explains rr parses flags first and suggests the pass-through form: `rr <task> -- <args>`. rr's own flags (`--local`, `--tail`, ...) parse unchanged.

## Verification

- Full unit suite green, golangci-lint 0 issues
- `./scripts/e2e-test.sh --quick`: 81 pass / 0 fail (includes the new `--config` assertion)
- All three fixes re-verified manually against m4-mini from the opendata repo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pytest quiet-mode result reporting, including passed, failed, skipped, and error counts.
  * Invalid `--config` paths now fail clearly instead of falling back to another configuration.
  * Improved unknown task-flag errors with guidance to use `rr <task> -- <args>`.
* **Documentation**
  * Updated the changelog with details of these fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->