### PR TITLE
docs: update changelog for v0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.23.1] - 2026-07-26
 
 ### Fixed
 


### PR DESCRIPTION
Stamps the [Unreleased] QA fixes as [0.23.1] - 2026-07-26 ahead of tagging the patch release.