### PR TITLE
docs: update changelog for v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.24.0] - 2026-07-30
 
 ### Breaking Changes
 


### PR DESCRIPTION
Promotes the `[Unreleased]` section to `[0.24.0]` ahead of tagging.

Minor rather than patch: the branch includes a documented breaking change (ad-hoc `rr run`/`rr exec` now execute in the subdirectory you invoked them from) plus two `feat:` commits.

https://claude.ai/code/session_01SZYTXCNEUSCqAZqtqrRXdD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the changelog to mark documented breaking changes, additions, and fixes as part of the 0.24.0 release dated July 30, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->