### PR TITLE
fix: bump Go to 1.25.13 to resolve govulncheck failures

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rileyhilliard/rr
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/charmbracelet/bubbles v1.0.0


### PR DESCRIPTION
## Summary
- Bumps Go from 1.25.12 to 1.25.13 in go.mod
- Fixes 4 stdlib vulnerabilities (GO-2026-5975, GO-2026-5971, GO-2026-5972, GO-2026-5026) that cause the Security scan CI job to fail
- Unblocks all 7 open Dependabot PRs which are otherwise green

## Test plan
- [x] `go build ./...` passes
- [x] All unit and integration tests pass
- [x] Lint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s Go language version to 1.25.13.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->